### PR TITLE
Fix form dropdown js example code

### DIFF
--- a/server/documents/collections/form.html.eco
+++ b/server/documents/collections/form.html.eco
@@ -392,7 +392,7 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
       Dropdown will automatically convert <code>select</code> elements initialized as dropdowns. For more details check out <a href="/modules/dropdown.html#usage">the dropdown docs</a>
     </div>
     <div class="code" data-type="javascript" data-label="true">
-    $('select.dropdown')
+    $('.selection.dropdown')
       .dropdown()
     ;
     </div>


### PR DESCRIPTION
Current version does not work, as it selects a `select` element, which is not even part of the dropdown html.

Note: I did not test this with Fomantic, just resubmitting https://github.com/Semantic-Org/Semantic-UI-Docs/pull/407 here, as I have heard this is the new thing! :smile: