### PR TITLE
[Toast] className title to header

### DIFF
--- a/server/documents/modules/toast.html.eco
+++ b/server/documents/modules/toast.html.eco
@@ -147,8 +147,7 @@ themes      : ['Default']
             message: 'I got my style from the message class',
             class : 'purple',
             className: {
-                toast: 'ui message',
-                title: 'ui header'
+                toast: 'ui message'
             }
           })
         ;
@@ -497,7 +496,7 @@ themes      : ['Default']
       icon         : 'icon',
       visible      : 'visible',
       content      : 'content',
-      title        : 'title'
+      title        : 'header'
     }
             </div>
           </td>


### PR DESCRIPTION
Docs changed according to https://github.com/fomantic/Fomantic-UI/pull/178

Simplifies usage with `ui message` and follows the naming standard of  sui for titles/headers