### PR TITLE
Changed Semantic to Fomantic at related places. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ fomantic/
 
 * Clone both repos to respective folders
 * npm install in both directories
-* Go through Semantic UI installer steps (auto)
+* Go through Fomantic UI installer steps (auto)
 * In `./ui` folder `gulp build-docs` (builds files to ./docs)
 * In `./docs` folder `docpad install` then `docpad run`
 * Go to http://localhost:9778/ docs should be there
@@ -72,7 +72,7 @@ docpad deploy-ghpages --env static
 
 If you find any typos or mistakes, submitting a fix is easy!
 
-- [Open the `documents/` folder](https://github.com/Semantic-Org/Semantic-UI-Docs/tree/master/server/documents) on GitHub
+- [Open the `documents/` folder](https://github.com/fomantic/Fomantic-UI-Docs/tree/master/server/documents) on GitHub
 - Click the “Edit” button on the appropriate page
 - Click to submit a pull request
 

--- a/server/documents/cla.html.eco
+++ b/server/documents/cla.html.eco
@@ -2,7 +2,7 @@
 layout      : 'default'
 css         : 'cla'
 title       : "Contributor License Agreement"
-description : 'Contribute to Semantic UI responsibly'
+description : 'Contribute to Fomantic UI responsibly'
 type        : 'Legal'
 ---
 
@@ -13,13 +13,13 @@ type        : 'Legal'
     <i class="help circle icon"></i>
     <div class="content">
       <div class="header">What's in a Contributor License Agreement (CLA)?</div>
-      This CLA makes sure that you are entitled to contribute to Semantic UI (you are not bound by a policy that prohibits you) and that you understand parts of your code may be used in derivative works. Additionally this agreement helps to legally protect Semantic UI should you later decide that you no longer want to contribute your code.
+      This CLA makes sure that you are entitled to contribute to Fomantic UI (you are not bound by a policy that prohibits you) and that you understand parts of your code may be used in derivative works. Additionally this agreement helps to legally protect Fomantic UI should you later decide that you no longer want to contribute your code.
     </div>
   </div>
   <div class="ui tab active" data-tab="individual">
-    <h1>Semantic UI Individual Contributor License Agreement</h1>
+    <h1>Fomantic UI Individual Contributor License Agreement</h1>
 
-    <p>Thank you for your interest in contributing to Semantic UI ("We" or "Us").</p>
+    <p>Thank you for your interest in contributing to Fomantic UI ("We" or "Us").</p>
 
     <p>This contributor agreement ("Agreement") documents the rights granted by contributors to Us. To make this document effective, please sign it and send it to Us by email or electronic submission, following the instructions at [URL]. This is a legally binding document, so please read it carefully before agreeing to it. The Agreement may cover more than one software project managed by Us.</p>
 
@@ -100,8 +100,8 @@ type        : 'Legal'
     <p>6.5 If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and which is enforceable.  The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.</p>
   </div>
   <div class="ui tab" data-tab="entity">
-    <h1>Semantic UI Entity Contributor License Agreement</h1>
-    <p>Thank you for your interest in contributing to Semantic UI ("We" or "Us").</p>
+    <h1>Fomantic UI Entity Contributor License Agreement</h1>
+    <p>Thank you for your interest in contributing to Fomantic UI ("We" or "Us").</p>
 
     <p>This contributor agreement ("Agreement") documents the rights granted by contributors to Us. To make this document effective, please sign it and send it to Us by email or electronic submission, following the instructions at . This is a legally binding document, so please read it carefully before agreeing to it. The Agreement may cover more than one software project managed by Us.</p>
 

--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -47,7 +47,7 @@ themes      : ['Default']
 
       <p>The example below shows four <code>four wide</code> columns will fit in the first row, <code>16 / 4 = 4</code>, and three various sized columns in the second row. <code>2 + 8 + 6 = 16</code></p>
 
-      <p>The default column count, and other arbitrary features of grids can be changed by adjusting Semantic UI's underlying <a href="/usage/theming.html">theming variables</a>.</p>
+      <p>The default column count, and other arbitrary features of grids can be changed by adjusting Fomantic UI's underlying <a href="/usage/theming.html">theming variables</a>.</p>
 
       <div class="ui grid">
         <div class="four wide column"></div>
@@ -408,7 +408,7 @@ themes      : ['Default']
     </div>
     <div class="example" data-class="mobile reversed">
       <h4 class="ui header">Reverse Order</h4>
-      <p>Semantic includes special <a href="#reversed"><code>reversed</code></a> variations that allow you to reverse the order of columns or rows by device</p>
+      <p>Fomantic includes special <a href="#reversed"><code>reversed</code></a> variations that allow you to reverse the order of columns or rows by device</p>
       <div class="ui mobile reversed equal width grid">
         <div class="column">
           First

--- a/server/documents/elements/container.html.eco
+++ b/server/documents/elements/container.html.eco
@@ -83,7 +83,7 @@ themes      : ['Default']
         </tbody>
       </table>
       <h3 class="ui header">Responsive Visibility</h3>
-      <p>Since variations in Semantic UI are only assigned in the scope of components, there are no "free floating" responsive class names, however some components include responsive variations to help ease responsive design. <a href="/collections/grid.html#device-visibility">Grid</a> for example, includes responsive classes for hiding or showing <code>column</code>, <code>row</code> based on device type.</p>
+      <p>Since variations in Fomantic UI are only assigned in the scope of components, there are no "free floating" responsive class names, however some components include responsive variations to help ease responsive design. <a href="/collections/grid.html#device-visibility">Grid</a> for example, includes responsive classes for hiding or showing <code>column</code>, <code>row</code> based on device type.</p>
 
       <a href="/collections/grid.html#device-visibility" class="ui secondary button">See grid responsive variations <i class="right chevron icon"></i></a>
 

--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -32,10 +32,10 @@ themes      : ['Default']
     <h2 class="ui header">Icon Set</h2>
     <p>An icon set contains an arbitrary number of glyphs</p>
     <div class="ui ignored warning message">
-      Icons serve a very similar function to text in a page. In Semantic icons receive a special tag <code>&lt;i&gt;</code> which allow for an abbreviated markup when sitting along-side text.
+      Icons serve a very similar function to text in a page. In Fomantic icons receive a special tag <code>&lt;i&gt;</code> which allow for an abbreviated markup when sitting along-side text.
     </div>
 
-    <div class="ui ignored message">Semantic includes a complete port of <a href="https://fontawesome.com/" target="_blank">Font Awesome 5.4.1</a> designed by the <a href="https://twitter.com/fontawesome">FontAwesome</a> team for its standard icon set.</div>
+    <div class="ui ignored message">Fomantic includes a complete port of <a href="https://fontawesome.com/" target="_blank">Font Awesome 5.4.1</a> designed by the <a href="https://twitter.com/fontawesome">FontAwesome</a> team for its standard icon set.</div>
 
     <div class="icon example">
       <h4 class="ui header">Accessibility</h4>

--- a/server/documents/elements/image.html.eco
+++ b/server/documents/elements/image.html.eco
@@ -158,7 +158,7 @@ themes      : ['Default']
     <h4 class="ui header">Size</h4>
     <p>An image may appear at different sizes</p>
     <div class="ui ignored info message">
-      Semantic uses arbitrary default values for image sizes from mini to massive. It is recommended to update these with values used in your project in <code>image.variables</code>.
+      Fomantic uses arbitrary default values for image sizes from mini to massive. It is recommended to update these with values used in your project in <code>image.variables</code>.
     </div>
     <table class="ui definition table">
       <thead>

--- a/server/documents/globals/reset.html.eco
+++ b/server/documents/globals/reset.html.eco
@@ -18,9 +18,9 @@ themes      : ['Default', 'Basic', 'Resetcss']
 <div class="main ui container">
   <div class="ui active tab" data-tab="overview">
     <h2 class="ui dividing header">What's In Our Reset</h2>
-    <p>Semantic's default theme includes the latest <a href="http://necolas.github.io/normalize.css/">Normalize CSS</a> to provide a base line HTML reset. In addition, Semantic UI requires a <b>Box-sizing</b> reset, to make sure that elements handle width definitions in the same way.</p>
+    <p>Fomantic's default theme includes the latest <a href="http://necolas.github.io/normalize.css/">Normalize CSS</a> to provide a base line HTML reset. In addition, Fomantic UI requires a <b>Box-sizing</b> reset, to make sure that elements handle width definitions in the same way.</p>
     <div class="ui text message info ignore">
-      The reset is required for Semantic UI components to function properly, and should also be included when using individual components.
+      The reset is required for Fomantic UI components to function properly, and should also be included when using individual components.
     </div>
 
     <h2 class="ui dividing header">Reset Options</h2>

--- a/server/documents/globals/site.html.eco
+++ b/server/documents/globals/site.html.eco
@@ -28,7 +28,7 @@ themes      : ['Default', 'GitHub', 'Material']
 
   <h3 class="ui header">Theming</h3>
 
-  <p>Customizing site variables is an important part of using Semantic UI, to learn more about global site variables visit our <a href="/usage/theming.html">theming guide</a>.</p>
+  <p>Customizing site variables is an important part of using Fomantic UI, to learn more about global site variables visit our <a href="/usage/theming.html">theming guide</a>.</p>
 
   <h2 class="ui dividing header">Content</h2>
 

--- a/server/documents/index.html.eco
+++ b/server/documents/index.html.eco
@@ -89,7 +89,7 @@ standalone : false
       <div class="twelve wide column">
         <img class="ui fluid image" src="/images/devices.png">
         <h1 class="ui header">Design Beautiful Websites Quickly</h1>
-        <p>Semantic is a development framework that helps create beautiful, responsive layouts using human-friendly HTML.</p>
+        <p>Fomantic is a development framework that helps create beautiful, responsive layouts using human-friendly HTML.</p>
       </div>
     </div>
   </div>
@@ -97,7 +97,7 @@ standalone : false
     <div class="row">
       <div class="seven wide column">
         <h2 class="ui header">Concise HTML</h2>
-        <p>Semantic UI treats words and classes as exchangeable concepts.</p>
+        <p>Fomantic UI treats words and classes as exchangeable concepts.</p>
         <p>Classes use syntax from natural languages like noun/modifier relationships, word order, and plurality to link concepts intuitively.</p>
         <p>Get the same benefits as <a href="https://en.bem.info" target="_blank">BEM</a> or <a href="https://smacss.com" target="_blank">SMACSS</a>, but without the tedium.</p>
         </p>
@@ -121,7 +121,7 @@ standalone : false
     <div class="row">
       <div class="seven wide column">
         <h2 class="ui header">Intuitive Javascript</h2>
-        <p>Semantic uses simple phrases called behaviors that trigger functionality.</p>
+        <p>Fomantic uses simple phrases called behaviors that trigger functionality.</p>
         <p>Any arbitrary decision in a component is included as a setting that developers can modify.</p>
       </div>
       <div class="nine wide column">
@@ -189,7 +189,7 @@ standalone : false
         <img src="/images/icons/theming.png" class="ui icon image">
         Unbelievable Theming
       </h1>
-      <p>Semantic comes equipped with an intuitive inheritance system and high level theming variables that let you have complete design freedom.</p>
+      <p>Fomantic comes equipped with an intuitive inheritance system and high level theming variables that let you have complete design freedom.</p>
       <p>Develop your UI once, then deploy with the same code everywhere.</p>
       <div class="ui large source button" style="display:none;">
         <i class="docs code icon"></i> View Source
@@ -200,7 +200,7 @@ standalone : false
         <span class="text">Select Theme</span>
         <i class="dropdown icon"></i>
         <div class="menu ui transition hidden" tabindex="-1">
-          <div data-value="Default" class="item">Semantic UI</div>
+          <div data-value="Default" class="item">Fomantic UI</div>
           <div data-value="Amazon" class="item">Amazon</div>
           <div data-value="Material" class="item">Google Material</div>
           <div data-value="GitHub" class="item">GitHub</div>
@@ -271,7 +271,7 @@ standalone : false
           5000+ Commits
         </h2>
         <p>
-          Semantic UI is a <b>free open source</b> project already used in multiple <a href="http://www.quirky.com" target="_blank">large</a> scale <a href="http://www.newrepublic.com" target="_blank">production</a> environments.
+          Fomantic UI and Semantic UI are <b>free open source</b> projects already used in multiple <a href="http://www.quirky.com" target="_blank">large</a> scale <a href="http://www.newrepublic.com" target="_blank">production</a> environments.
         </p>
         <a href="https://github.com/fomantic/Fomantic-UI/issues" class="ui large button">Visit GitHub</a>
       </div>
@@ -285,7 +285,7 @@ standalone : false
         <img src="/images/icons/toolbox.png" class="ui icon image">
         Unbelievable Breadth
       </h1>
-      <p>Definitions aren't limited to just buttons on a page. Semantic's components allow several distinct types of definitions: elements, collections, views, modules and behaviors which cover the gamut of interface design.</p>
+      <p>Definitions aren't limited to just buttons on a page. Fomantic's components allow several distinct types of definitions: elements, collections, views, modules and behaviors which cover the gamut of interface design.</p>
       <a class="ui large primary button" href="/usage/layout.html">
         See Layout Examples
         <i class="right chevron icon"></i>
@@ -952,7 +952,7 @@ standalone : false
           <img class="ui icon image" src="/images/icons/mobile.png">
           Responsively Designed
         </h2>
-        <p>Semantic is <b>designed completely with em</b> making responsive sizing a breeze. Design <em>variations</em> built into elements allow you to make the choice how content adjusts for tablet and mobile.</p>
+        <p>Fomantic is <b>designed completely with em</b> making responsive sizing a breeze. Design <em>variations</em> built into elements allow you to make the choice how content adjusts for tablet and mobile.</p>
         <a class="ui large button" href="/usage/layout.html">Responsive Examples</a>
       </div>
       <div class="column">
@@ -960,7 +960,7 @@ standalone : false
           <img class="ui icon image" src="/images/icons/heart.png">
           Partners with Libraries You Love
         </h2>
-        <p>Semantic has integrations with <b>React, Angular, Meteor, Ember</b> and many other frameworks to help organize your UI layer alongside your application logic.</p>
+        <p>Fomantic has integrations with <b>React, Angular, Meteor, Ember</b> and many other frameworks to help organize your UI layer alongside your application logic.</p>
         <a class="ui large button" href="/introduction/integrations.html">See Integrations</a>
       </div>
     </div>

--- a/server/documents/introduction/advanced-usage.html.eco
+++ b/server/documents/introduction/advanced-usage.html.eco
@@ -65,7 +65,7 @@ type        : 'Introduction'
 
     <div class="no example">
       <h4>Right-to-left (RTL) Languages</h4>
-      <p>Including the flag <code>rtl:true</code> will build Semantic UI using <a href="https://github.com/MohammadYounes/rtlcss" target="_blank">RTLCSS</a>.</p>
+      <p>Including the flag <code>rtl:true</code> will build Fomantic UI using <a href="https://github.com/MohammadYounes/rtlcss" target="_blank">RTLCSS</a>.</p>
       <p>To build both LTR and RTL versions use the flag <code>rtl: 'both'</code></p>
       <div class="ignored code" data-type="JS" data-title="semantic.json">
        {
@@ -94,10 +94,10 @@ type        : 'Introduction'
       </div>
   </div>
 
-  <h2 class="ui dividing header">Prototyping with Semantic UI</h2>
+  <h2 class="ui dividing header">Prototyping with Fomantic UI</h2>
   <div class="no example">
     <h4>Sketch Files</h4>
-    <p>If you are looking to prototype layouts using <a href="http://bohemiancoding.com/sketch/" target="_blank">Sketch</a> with Semantic UI check out <a href="https://github.com/guacamoly/semantic-ui-kit-for-sketch" target="_blank">Semantic UI Sketch Files</a></p>
+    <p>If you are looking to prototype layouts using <a href="http://bohemiancoding.com/sketch/" target="_blank">Sketch</a> with Fomantic UI check out <a href="https://github.com/guacamoly/semantic-ui-kit-for-sketch" target="_blank">Semantic UI Sketch Files</a></p>
     <img class="ui bordered rounded fluid image" src="https://github.com/guacamoly/semantic-ui-kit-for-sketch/raw/master/snapshot.jpg?raw=true">
   </div>
 
@@ -105,14 +105,14 @@ type        : 'Introduction'
 
   <div class="no example">
     <h4>CDN Releases</h4>
-    <p>Individual components are available on <a href="https://www.jsdelivr.com/projects/semantic-ui">jsDelivr</a></p>
+    <p>Individual components are available on <a href="https://www.jsdelivr.com/package/npm/fomantic-ui">jsDelivr</a></p>
     <div class="code">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@<%= @getVersion() %>/dist/semantic.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@<%= @getVersion() %>/dist/semantic.min.css">
     </div>
     <div class="code">
-    <script src="https://cdn.jsdelivr.net/npm/semantic-ui@<%= @getVersion() %>/dist/semantic.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fomantic-ui@<%= @getVersion() %>/dist/semantic.min.js"></script>
     </div>
-    <a class="ui button" href="https://www.jsdelivr.com/projects/semantic-ui" target="_blank">View All CDN Files</a>
+    <a class="ui button" href="https://www.jsdelivr.com/package/npm/fomantic-ui" target="_blank">View All CDN Files</a>
   </div>
 
   <div class="no example">
@@ -170,14 +170,14 @@ type        : 'Introduction'
 
   <div class="no example">
     <h4>Download Docs Server</h4>
-    <p>The easiest way to get <a href="https://github.com/fomantic/Fomantic-UI-Docs/">Semantic UI docs</a> is to clone the repo</p>
+    <p>The easiest way to get <a href="https://github.com/fomantic/Fomantic-UI-Docs/">Fomantic UI docs</a> is to clone the repo</p>
     <div class="code">
       git clone https://github.com/fomantic/Fomantic-UI-Docs.git
     </div>
   </div>
   <div class="no example">
     <h4>Install Dependencies</h4>
-    <p>Semantic UI's documentation is written in <a href="http://www.docpad.org" target="_blank">Docpad</a> an amazing static site generator built in NodeJS</p>
+    <p>Fomantic UI's documentation is written in <a href="http://www.docpad.org" target="_blank">Docpad</a> an amazing static site generator built in NodeJS</p>
     <div class="code">
       cd docs/
       npm install
@@ -186,14 +186,14 @@ type        : 'Introduction'
 
   <div class="no example">
     <h4>A Note About Paths</h4>
-    <p>Semantic UI's <a href="introduction/build-tools.html">build tools</a> include two special commands <code>build-docs</code> and <code>serve-docs</code> for use with the documentation. These will pass changes from the ui/ folder directly to a live docs server.</p>
+    <p>Fomantic UI's <a href="introduction/build-tools.html">build tools</a> include two special commands <code>build-docs</code> and <code>serve-docs</code> for use with the documentation. These will pass changes from the ui/ folder directly to a live docs server.</p>
     <p>These gulp tasks expect two sibling folders</p>
     <div class="ui list">
       <div class="item">
         <i class="folder icon"></i>
         <div class="content">
           <div class="header">ui/</div>
-          <div class="description">Files from semantic ui repo</div>
+          <div class="description">Files from fomantic ui repo</div>
         </div>
       </div>
       <div class="item">

--- a/server/documents/introduction/build-tools.html.eco
+++ b/server/documents/introduction/build-tools.html.eco
@@ -5,7 +5,7 @@ standalone  : true
 order       : 3
 
 title       : 'Build Tools'
-description : 'Using Gulp with Semantic UI'
+description : 'Using Gulp with Fomantic UI'
 type        : 'Introduction'
 ---
 <%- @partial('header') %>
@@ -16,7 +16,7 @@ type        : 'Introduction'
 
   <div class="no example">
     <h4>30 Second Explanation</h4>
-    <p><a href="/introduction/getting-started.html">Download Semantic UI</a> navigate to the install folder then run a <a href="#gulp-commands">gulp command</a>.</p>
+    <p><a href="/introduction/getting-started.html">Download Fomantic UI</a> navigate to the install folder then run a <a href="#gulp-commands">gulp command</a>.</p>
 
     <p>To build all files:</p>
     <div class="code" data-type="bash">
@@ -30,7 +30,7 @@ type        : 'Introduction'
   </div>
   <div class="no example">
     <h4>Why Build Tools?</h4>
-    <p>Semantic UI uses Gulp for several reasons:</p>
+    <p>Fomantic UI uses Gulp for several reasons:</p>
     <div class="ui large bulleted list">
       <div class="item">Process LESS files with <a href="/usage/theming.html">theming variables</a></div>
       <div class="item">Add vendor prefixes for <a href="https://github.com/fomantic/Fomantic-UI/blob/master/tasks/config/project/tasks.js#L96">supported browsers</a> with <a href="https://github.com/postcss/autoprefixer" target="_blank">autoprefixer</a></div>
@@ -42,7 +42,7 @@ type        : 'Introduction'
   </div>
   <div class="no example">
     <h3 class="ui header">Folder Structure</h3>
-    <p>A Semantic UI project includes the following folder structure.</p>
+    <p>A Fomantic UI project includes the following folder structure.</p>
     <div class="ui list">
       <div class="item">
         <i class="folder icon"></i>
@@ -185,14 +185,14 @@ type        : 'Introduction'
 
   <div class="no example">
     <h4>semantic.json</h4>
-    <p>Build tool settings are stored in a special file called <code>semantic.json</code> It can be included in any folder that is in a parent folder of the semantic install folder.</p>
+    <p>Build tool settings are stored in a special file called <code>semantic.json</code> It can be included in any folder that is in a parent folder of the fomantic install folder.</p>
     <p>If you used the npm or meteor, a <code>semantic.json</code> file is automatically generated for you in the root of your project. If you used a different package manager you can run <code>gulp install</code> to run the interactive installer.</p>
     <div class="ignored code">
     {
       // base path added to all other paths specified in "paths"
       "base": "",
 
-      // current version of Semantic UI
+      // current version of Fomantic UI
       "version": "<%= @getVersion() %>",
 
       "paths": {

--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -5,7 +5,7 @@ standalone  : true
 order       : 1
 
 title       : 'Getting Started'
-description : 'Getting up and running with Semantic UI'
+description : 'Getting up and running with Fomantic UI'
 type        : 'Main'
 ---
 <script src="/javascript/started.js"></script>
@@ -20,11 +20,11 @@ type        : 'Main'
 
     <h4 class="ui header">Using Build Tools</h4>
 
-    <p>Semantic UI packaged Gulp build tools so your project can preserve its <a href="/usage/theming.html">own theme changes</a>.</p>
-    <p>The easiest way to install Semantic UI is our NPM package which contains special install scripts to make setup interactive and updates seamless.</p>
+    <p>Fomantic UI packaged Gulp build tools so your project can preserve its <a href="/usage/theming.html">own theme changes</a>.</p>
+    <p>The easiest way to install Fomantic UI is our NPM package which contains special install scripts to make setup interactive and updates seamless.</p>
 
     <p>For installing with specific integrations like Ember, React, or Meteor, see our <a href="/introduction/integrations.html">integration guide</a></p>
-    <p>For integrating Semantic UI tasks into your own build tools, or using a CDN see our <a href="/introduction/advanced-usage.html">recipes</a> section.</p>
+    <p>For integrating Fomantic UI tasks into your own build tools, or using a CDN see our <a href="/introduction/advanced-usage.html">recipes</a> section.</p>
 
   </div>
 
@@ -127,7 +127,7 @@ type        : 'Main'
 
   <div class="no example">
     <h4>All Set!</h4>
-    <p>Well done! Semantic UI is now ready to be used.</p>
+    <p>Well done! Fomantic UI is now ready to be used.</p>
 
     <div class="three column divided stackable center aligned ui grid">
       <div class="column">
@@ -145,7 +145,7 @@ type        : 'Main'
       <div class="column">
         <div class="ui icon header">
           <i class="food circular icon"></i>
-          See <a href="/introduction/advanced-usage.html">recipes</a> for using Semantic UI in your project
+          See <a href="/introduction/advanced-usage.html">recipes</a> for using Fomantic UI in your project
         </div>
       </div>
     </div>

--- a/server/documents/introduction/glossary.html.eco
+++ b/server/documents/introduction/glossary.html.eco
@@ -5,7 +5,7 @@ standalone  : true
 order       : 5
 
 title       : 'Glossary'
-description : 'Jargon specific to Semantic UI'
+description : 'Jargon specific to Fomantic UI'
 type        : 'Introduction'
 ---
 <%- @partial('header') %>
@@ -16,7 +16,7 @@ type        : 'Introduction'
 
 <div class="no example">
   <h4>Types of Components</h4>
-  <p>Semantic UI classifies components into different definition types depending on its qualities. Each of these five types uses a unique definition format.</p>
+  <p>Fomantic UI classifies components into different definition types depending on its qualities. Each of these five types uses a unique definition format.</p>
   <table class="ui large very padded definition table">
     <tbody>
       <tr>
@@ -62,7 +62,7 @@ type        : 'Introduction'
 
 <div class="no example">
   <h4>Project Terminology</h4>
-  <p>Semantic UI classifies components into separate definition groupings.<p>
+  <p>Fomantic UI classifies components into separate definition groupings.<p>
 
   <table class="ui large very padded definition table">
     <tbody>
@@ -157,7 +157,7 @@ type        : 'Introduction'
     <tr>
       <td class="three wide">Namespace</td>
       <td>A name given to an element for the explicit purpose of containing the application of properties.</p>
-      <p>In Semantic UI, components are given the class name <code>ui</code> to help distinguish them from parts of elements in code, and to provide a namespace for definitions which can limit the scope of CSS rules.</td>
+      <p>In Fomantic UI, components are given the class name <code>ui</code> to help distinguish them from parts of elements in code, and to provide a namespace for definitions which can limit the scope of CSS rules.</td>
     </tr>
     <tr>
       <td>Gulp</td>

--- a/server/documents/introduction/integrations.html.eco
+++ b/server/documents/introduction/integrations.html.eco
@@ -5,7 +5,7 @@ standalone  : true
 order       : 2
 
 title       : 'Integrations'
-description : 'Using Semantic UI with Other Libraries'
+description : 'Using Fomantic UI with Other Libraries'
 type        : 'Introduction'
 ---
 <%- @partial('header') %>
@@ -19,7 +19,7 @@ type        : 'Introduction'
   <div class="example">
     <h4>Contribute to React Development</h4>
     <p>Semantic UI React bindings are still in development, but are available for most components.</p>
-    <a href="https://github.com/fomantic/Fomantic-UI-React" target="_blank" class="ui button"><i class="github icon"></i>Visit React Repo</a>
+    <a href="https://github.com/Semantic-Org/Semantic-UI-React" target="_blank" class="ui button"><i class="github icon"></i>Visit React Repo</a>
   </div>
 
   <h2 class="ui dividing header">
@@ -114,7 +114,7 @@ type        : 'Introduction'
   <div class="no example">
     <h4>Issues & Debugging</h4>
     <p>For help with Semantic UI Meteor, and for the latest updates, please visit the repository home on GitHub</p>
-    <a href="https://github.com/fomantic/Fomantic-UI-Meteor" target="_blank" class="ui button"><i class="github icon"></i> Visit Meteor Repo</a>
+    <a href="https://github.com/Semantic-Org/Semantic-UI-Meteor" target="_blank" class="ui button"><i class="github icon"></i> Visit Meteor Repo</a>
   </div>
 
   <h2 class="ui header">
@@ -145,7 +145,7 @@ type        : 'Introduction'
   <div class="example">
     <h4 class="ui header">Get Coding</h4>
     <p>For example of individual components check out the GitHub repository</p>
-    <a href="https://github.com/fomantic/Fomantic-UI-Ember" target="_blank" class="ui button"><i class="github icon"></i> Visit Ember Repo</a>
+    <a href="https://github.com/Semantic-Org/Semantic-UI-Ember" target="_blank" class="ui button"><i class="github icon"></i> Visit Ember Repo</a>
   </div>
 
   <h2 class="ui dividing header">
@@ -155,6 +155,6 @@ type        : 'Introduction'
   <div class="example">
     <h4>Contribute to Angular Development</h4>
     <p>Semantic UI angular bindings are still in development, but are available for some components</p>
-    <a href="https://github.com/fomantic/Fomantic-UI-Angular" target="_blank" class="ui button"><i class="github icon"></i>Visit Angular Repo</a>
+    <a href="https://github.com/Semantic-Org/Semantic-UI-Angular" target="_blank" class="ui button"><i class="github icon"></i>Visit Angular Repo</a>
   </div>
 </div>

--- a/server/documents/modules/nag.html.eco
+++ b/server/documents/modules/nag.html.eco
@@ -67,7 +67,7 @@ type        : 'Future Module'
     <h2 class="ui dividing header">Support Development</h2>
     <div class="no example">
 
-      <p>You can help support the future development of the Semantic UI project, and help boost the priority of this component by donating to Semantic UI development.</p>
+      <p>You can help support the future development of the Fomantic UI project, and help boost the priority of this component by donating to Fomantic UI development.</p>
 
       <p>Please be sure to leave a note in the comments to indicate that you are interested in the development of this particular component.</p>
 

--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -439,7 +439,7 @@ themes      : ['Default']
     <div class="example">
       <h4 class="ui header">Wide Popup Menu</h4>
       <p>An easier way to display complex content, like a wide popup menu is to have the popup content as a pre-  existing part of your page's HTML.</p>
-      <p>Using the setting <code>inline: true</code> will let Semantic know to display the next sibling <code>ui  popup</code> element after the activator.</p>
+      <p>Using the setting <code>inline: true</code> will let Fomantic know to display the next sibling <code>ui  popup</code> element after the activator.</p>
 
       <p>Tweaking settings like the delay for show, and hide, and making the menu hoverable will help it function   more like a dropdown menu</p>
 

--- a/server/documents/modules/tab.html.eco
+++ b/server/documents/modules/tab.html.eco
@@ -601,7 +601,7 @@ themes      : ['Default']
       <h4 class="ui header">...with an API Behavior</h4>
       <p>Tabs provide an optional coupling with API which allow you to specify a templated API endpoint that a tab can query</p>
       <p>Tabs will automatically pass the url variable <code>{$tab}</code> which can be replaced for RESTful API links.</p>
-      <p>To learn more about API behaviors built into semantic check out the API docs</p>
+      <p>To learn more about API behaviors built into fomantic check out the API docs</p>
       <a class="ui button" href="/behaviors/api.html">View API Docs <i class="right chevron icon"></i></a>
     </div>
 

--- a/server/documents/usage/layout.html.eco
+++ b/server/documents/usage/layout.html.eco
@@ -43,7 +43,7 @@ type        : 'Usage'
       <div class="content">
         <div class="header">Grid</div>
         <div class="description">
-          An introduction to using Semantic UI grids.
+          An introduction to using Fomantic UI grids.
         </div>
       </div>
     </a>

--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -718,7 +718,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
       </div>
       <div class="extra content">
         <div class="center aligned author">
-          <img class="ui avatar image" src="http://semantic-ui.com/images/avatar/small/jenny.jpg"> Jenny
+          <img class="ui avatar image" src="/images/avatar/small/jenny.jpg"> Jenny
         </div>
       </div>
     </div>

--- a/server/files/stylesheets/library/basic.icon.css
+++ b/server/files/stylesheets/library/basic.icon.css
@@ -1,6 +1,6 @@
 /*
  * # Semantic - Icon
- * http://github.com/jlukic/semantic-ui/
+ * https://github.com/fomantic/fomantic-ui/
  *
  *
  * Copyright 2013 Contributors


### PR DESCRIPTION
Reverted to Semantic for Links to Repos (Components, Angular,React,Ember, Gulp-Example...) which are currently not in scope for fomantic or only exists in semantic-org