### PR TITLE
Disable Adblock code, dont even include the library

### DIFF
--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -1444,14 +1444,14 @@ semantic.ready = function() {
   if(window.Transifex !== undefined) {
     window.Transifex.live.onTranslatePage(handler.showLanguageModal);
   }
-
+/*
   if(typeof detectAdBlock === 'undefined') {
     handler.showBeg();
   }
   else {
     detectAdBlock.onDetected(handler.showBeg);
   }
-
+*/
   if(window.location.hash) {
     var
       $element = $(window.location.hash),

--- a/server/partials/library-javascript.html.eco
+++ b/server/partials/library-javascript.html.eco
@@ -1,6 +1,6 @@
 <% if 'development' in @getEnvironments(): %>
   <script src="/javascript/library/jquery.js"></script>
-<%#  <script src="/javascript/library/detect.js"></script> %>
+<% #  <script src="/javascript/library/detect.js"></script> %>
   <script src="/javascript/library/clipboard.js"></script>
   <script src="/javascript/library/cookie.js"></script>
   <script src="/javascript/library/easing.js"></script>
@@ -10,7 +10,7 @@
   <script src="/javascript/library/tablesort.js"></script>
   <script src="/javascript/library/underscore.js"></script>
 <% else: %>
-<%#  <script src="/javascript/library/detect.min.js"></script> %>
+<% #  <script src="/javascript/library/detect.min.js"></script> %>
   <script src="/javascript/library/jquery.min.js"></script>
   <script src="/javascript/library/clipboard.min.js"></script>
   <script src="/javascript/library/cookie.min.js"></script>

--- a/server/partials/library-javascript.html.eco
+++ b/server/partials/library-javascript.html.eco
@@ -1,6 +1,6 @@
 <% if 'development' in @getEnvironments(): %>
   <script src="/javascript/library/jquery.js"></script>
-  <script src="/javascript/library/detect.js"></script>
+<%#  <script src="/javascript/library/detect.js"></script> %>
   <script src="/javascript/library/clipboard.js"></script>
   <script src="/javascript/library/cookie.js"></script>
   <script src="/javascript/library/easing.js"></script>
@@ -10,7 +10,7 @@
   <script src="/javascript/library/tablesort.js"></script>
   <script src="/javascript/library/underscore.js"></script>
 <% else: %>
-  <script src="/javascript/library/detect.min.js"></script>
+<%#  <script src="/javascript/library/detect.min.js"></script> %>
   <script src="/javascript/library/jquery.min.js"></script>
   <script src="/javascript/library/clipboard.min.js"></script>
   <script src="/javascript/library/cookie.min.js"></script>


### PR DESCRIPTION
As the html code for the adblock was removed by #40 , the related JS code should be removed aswell to avoid js errors.
I just commented it out for now. Who knows if it might be of interested later