### PR TITLE
[Popup] Added new tooltip sizes and basic example

### DIFF
--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -225,13 +225,13 @@ themes      : ['Default']
     <div class="example">
       <h4 class="ui header">Basic</h4>
       <p>A tooltip can provide more basic formatting</p>
-      <div class="ui button" data-tooltip="The default theme's basic popup removes the pointing arrow." data-variation="basic">
+      <div class="ui button" data-tooltip="The default theme's basic tooltip removes the pointing arrow." data-variation="basic">
         Basic
       </div>
       <div class="ui button" data-tooltip="You can combine me" data-variation="tiny basic">
         Tiny Basic
       </div>
-      <div class="ui button" data-inverted data-tooltip="The default theme's basic popup removes the pointing arrow." data-variation="basic">
+      <div class="ui button" data-inverted data-tooltip="The default theme's basic tooltip removes the pointing arrow." data-variation="basic">
         Basic
       </div>
       <div class="ui button" data-inverted data-tooltip="You can combine me" data-variation="tiny basic">

--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -121,7 +121,9 @@ themes      : ['Default']
         <i class="add icon"></i>
       </div>
     </div>
-    <div class="another example">
+    <div class="example">
+      <h4 class="ui header">Position</h4>
+      <p></p>
       <div class="ui button" data-tooltip="Add users to your feed" data-position="top left">
         Top Left
       </div>
@@ -175,6 +177,65 @@ themes      : ['Default']
       </div>
       <div class="ui button" data-inverted data-tooltip="Add users to your feed" data-position="left center">
         Left Center
+      </div>
+    </div>
+
+    <div class="example">
+      <h4 class="ui header">Size</h4>
+      <p>A tooltip can vary in size</p>
+      <div class="ui button" data-tooltip="Add users to your feed" data-variation="mini">
+        Mini
+      </div>
+      <div class="ui button" data-tooltip="Add users to your feed" data-variation="tiny">
+        Tiny
+      </div>
+      <div class="ui button" data-tooltip="Add users to your feed" data-variation="small">
+       Small
+      </div>
+      <div class="ui button" data-tooltip="Add users to your feed" data-variation="medium">
+        Medium
+      </div>
+      <div class="ui button" data-tooltip="Add users to your feed" data-variation="large">
+        Large
+      </div>
+      <div class="ui button" data-tooltip="Add users to your feed" data-variation="huge">
+        Huge
+      </div>
+      <div class="ui divider"></div>
+      <div class="ui button" data-inverted data-tooltip="Add users to your feed" data-variation="mini">
+        Mini
+      </div>
+      <div class="ui button" data-inverted data-tooltip="Add users to your feed" data-variation="tiny">
+        Tiny
+      </div>
+      <div class="ui button" data-inverted data-tooltip="Add users to your feed" data-variation="small">
+       Small
+      </div>
+      <div class="ui button" data-inverted data-tooltip="Add users to your feed" data-variation="medium">
+        Medium
+      </div>
+      <div class="ui button" data-inverted data-tooltip="Add users to your feed" data-variation="large">
+        Large
+      </div>
+      <div class="ui button" data-inverted data-tooltip="Add users to your feed" data-variation="huge">
+        Huge
+      </div>
+    </div>
+
+    <div class="example">
+      <h4 class="ui header">Basic</h4>
+      <p>A tooltip can provide more basic formatting</p>
+      <div class="ui button" data-tooltip="The default theme's basic popup removes the pointing arrow." data-variation="basic">
+        Basic
+      </div>
+      <div class="ui button" data-tooltip="You can combine me" data-variation="tiny basic">
+        Tiny Basic
+      </div>
+      <div class="ui button" data-inverted data-tooltip="The default theme's basic popup removes the pointing arrow." data-variation="basic">
+        Basic
+      </div>
+      <div class="ui button" data-inverted data-tooltip="You can combine me" data-variation="tiny basic">
+        Tiny Basic
       </div>
     </div>
 


### PR DESCRIPTION
Added new tooltip sizes and basic example as of https://github.com/fomantic/Fomantic-UI/pull/202
![tooltip_size_basic](https://user-images.githubusercontent.com/18379884/48320761-6c498e00-e61d-11e8-8db0-0d564211775c.gif)
