### PR TITLE
[Form] Separate Radio buttons to their groups

### DIFF
--- a/server/documents/collections/form.html.eco
+++ b/server/documents/collections/form.html.eco
@@ -359,25 +359,25 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
         <label for="fruit">Select your second favorite fruit:</label>
         <div class="field">
           <div class="ui radio checkbox">
-            <input type="radio" name="fruit" checked />
+            <input type="radio" name="fruit2" checked />
             <label>Apples</label>
           </div>
         </div>
         <div class="field">
           <div class="ui radio checkbox">
-            <input type="radio" name="fruit" />
+            <input type="radio" name="fruit2" />
             <label>Oranges</label>
           </div>
         </div>
         <div class="field">
           <div class="ui radio checkbox">
-            <input type="radio" name="fruit" />
+            <input type="radio" name="fruit2" />
             <label>Pears</label>
           </div>
         </div>
         <div class="field">
           <div class="ui radio checkbox">
-            <input type="radio" name="fruit" />
+            <input type="radio" name="fruit2" />
             <label>Grapefruit</label>
           </div>
         </div>


### PR DESCRIPTION
### Description
The Radiobutton grouping example had all radiobuttons given the same name, so they technically belong to the same group, but the example suggested to have 2 different groups instead

### Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6681