### PR TITLE
[API] Added undocumented base-parameter

### DIFF
--- a/server/documents/behaviors/api.html.eco
+++ b/server/documents/behaviors/api.html.eco
@@ -1081,6 +1081,12 @@ type        : 'UI Behavior'
           <td>String or false</td>
         </tr>
         <tr>
+          <td>base</td>
+          <td>''</td>
+          <td>base URL to apply to all endpoints. Will be prepended to each given url</td>
+          <td>String</td>
+        </tr>
+        <tr>
           <td>urlData</td>
           <td>false</td>
           <td>Variables to use for replacement</td>


### PR DESCRIPTION
## Description
While talking in the SUI gitter channel, we came across a question if it's possible to implement a feature of having a central url being attached to all action urls at once.

After a while i found out this feature is already part of the API behaviour by using the `base` option...it is just not documented :disappointed: 

..so i added this option to the API docs