### PR TITLE
Feat: Icon alias search

### DIFF
--- a/server/files/javascript/icon.js
+++ b/server/files/javascript/icon.js
@@ -24,13 +24,15 @@ semantic.icon.ready = function() {
             var
               $icon = $(this).find('.icon'),
               icon  = $icon.attr('class').replace(' icon', ''),
+              terms = $icon.data('search-terms') || "",
               title = '<i class="' + icon +' icon"></i> ' + icon
             ;
             if(!_.findWhere(icons, { icon: icon})) {
               icons.push({
-                category : category,
-                title    : title,
-                icon     : icon
+                category    : category,
+                description : terms,
+                title       : title,
+                icon        : icon
               });
             }
           });

--- a/server/files/javascript/icon.js
+++ b/server/files/javascript/icon.js
@@ -11,7 +11,7 @@ semantic.icon.ready = function() {
     handler = {
       getIconList: function() {
         var
-          $examples   = $('.icon .example')
+          $examples   = $('.icon .example'),
           icons       = []
         ;
         $examples.each(function() {
@@ -23,7 +23,7 @@ semantic.icon.ready = function() {
           $icons.each(function() {
             var
               $icon = $(this).find('.icon'),
-              icon  = $icon.attr('class').replace(' icon', '')
+              icon  = $icon.attr('class').replace(' icon', ''),
               title = '<i class="' + icon +' icon"></i> ' + icon
             ;
             if(!_.findWhere(icons, { icon: icon})) {


### PR DESCRIPTION
# Description

Alias search allows users to search icons in other name.

Aliases are stored in `data-search-terms` attribute in `icons.html.eco` which is generated by icon-script. See the related PR 
* https://github.com/fomantic/icon-script/pull/5
* https://github.com/fomantic/icon-script/pull/6

# Note
This PR does NOT include changes in `server/documents/elements/icon.html.eco` (`data-search-terms`) intentionally (see https://github.com/fomantic/Fomantic-UI-Docs/pull/67#issuecomment-451013371). 
So icon search works fine but alias search do not.


# Screenshot

Aliases are shown in grey text as description of Search module.

![image](https://user-images.githubusercontent.com/127635/50616734-1adac280-0f2d-11e9-8e98-be534a0d5261.png)

# Closes 
https://github.com/Semantic-Org/Semantic-UI/issues/6313
