### PR TITLE
Style: ToC include active tab name

### DIFF
--- a/server/documents/introduction/new.html.eco
+++ b/server/documents/introduction/new.html.eco
@@ -4,7 +4,7 @@ css         : 'new'
 standalone  : true
 order       : 1
 
-title       : 'New in 2.7'
+title       : "What's New"
 description : 'An introduction to new features found in the latest release'
 type        : 'Main'
 ---

--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -373,6 +373,9 @@ semantic.ready = function() {
     getSafeName: function(text) {
       return text.replace(/\s+/g, '-').replace(/[^-,'A-Za-z0-9]+/g, '').toLowerCase();
     },
+    getActiveTabTitle: function() {
+      return $(".masthead .tabs.menu .active.item").text();
+    },
 
     getText: function($element) {
       $element = ($element.find('a').not('.label, .anchor').length > 0)
@@ -396,6 +399,7 @@ semantic.ready = function() {
         html      = '',
         pageTitle = handler.getPageTitle(),
         title     = pageTitle.charAt(0).toUpperCase() + pageTitle.slice(1),
+        activeTab = handler.getActiveTabTitle(),  
         $sticky,
         $rail
       ;
@@ -455,8 +459,12 @@ semantic.ready = function() {
         .addClass('ui sticky')
         .html($followMenu)
         //.prepend($advertisement)
-        .prepend('<h4 class="ui header">' + title + '</h4>')
+        .prepend('<h3 class="ui header">' + title + '</h3>')
       ;
+      if (activeTab !== "") {
+        console.log("activeTab: ", activeTab);
+        $sticky.find('h3.ui.header').after('<h4 class="ui header">' + activeTab + '</h4>');
+      }
       $rail = $('<div />')
         .addClass('ui dividing right rail')
         .html($sticky)


### PR DESCRIPTION
# Description

* Add active tab name (e.g. New in 2.x) in toc, not only in the page but also globally.
   * If no tabs menu on the page, it is just skipped.
* Change page title of `new.html` to `What's New`.

# Closes
#68.

# Screenshot

## Pages with tabs menu

### 1. What's New page
![fui-whats-new-toc-tabs](https://user-images.githubusercontent.com/127635/50618697-ed474680-0f37-11e9-9317-625d4b15dc65.gif)

### 2. Icon module page
![image](https://user-images.githubusercontent.com/127635/50618678-d3a5ff00-0f37-11e9-8f24-bb6ce428dfb5.png)

## Pages without tabs menu
![image](https://user-images.githubusercontent.com/127635/50618651-a6f1e780-0f37-11e9-9ed8-83924417d232.png)
