### PR TITLE
[Label] Right icon should have correct margin when placed after text

### DIFF
--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -359,7 +359,7 @@ themes      : ['Default', 'GitHub']
     </div>
     <div class="ui label">
       <i class="checkmark icon"></i>
-      Test
+      Test Passed
     </div>
     <div class="ui label">
       <i class="dog icon"></i>
@@ -379,7 +379,7 @@ themes      : ['Default', 'GitHub']
       <i class="mail icon"></i>
     </div>
     <div class="ui right icon label">
-      Test
+      Test Passed
       <i class="checkmark icon"></i>
     </div>
     <div class="ui right icon label">
@@ -399,12 +399,8 @@ themes      : ['Default', 'GitHub']
       Mail
     </div>
     <div class="ui label">
-      <i class="hoverable close icon"></i>
-      Close
-    </div>
-    <div class="ui label">
-      <i class="hoverable delete icon"></i>
-      Delete
+      <i class="hoverable times icon"></i>
+      Test Failed
     </div>
 
     <div class="ui right icon label">
@@ -412,12 +408,8 @@ themes      : ['Default', 'GitHub']
       <i class="hoverable mail icon"></i>
     </div>
     <div class="ui right icon label">
-      Close
-      <i class="hoverable close icon"></i>
-    </div>
-    <div class="ui right icon label">
-      Delete
-      <i class="hoverable delete icon"></i>
+      Test Failed
+      <i class="hoverable times icon"></i>
     </div>
   </div>
 
@@ -434,8 +426,42 @@ themes      : ['Default', 'GitHub']
       <i class="cat icon"></i>
     </div>
   </div>
-  
-  
+
+  <div class="another example" data-use-content="true">
+    <div class="ignored ui icon warning message">
+      <i class="warning sign icon"></i>
+      <div class="content">
+        For backward-compatibility during v2.x, <code>close</code>/<code>delete</code> icon...
+      
+        <ul>
+          <li>requires <code>left icon</code> added to parent <code>label</code> when the icon is placed in the left of label.</li>
+          <li>do not require <code>right icon</code> added to parent <code>label</code> when the icon is placed in the right of label.</li>
+          <li>have special style as same as <code>hoverable</code> variation when the icon is inside <code>label</code> which do not have <code>icon</code> class.</li>
+        </ul>
+      
+        This complicated rule may be simplified in v3.x.
+      </div>
+    </div>
+
+    <div class="ui left icon label">
+      <i class="hoverable close icon"></i>
+      Close
+    </div>
+    <div class="ui left icon label">
+      <i class="hoverable delete icon"></i>
+      Delete
+    </div>
+
+    <div class="ui label">
+      Close
+      <i class="close icon"></i>
+    </div>
+    <div class="ui label">
+      Delete
+      <i class="delete icon"></i>
+    </div>
+  </div>
+    
   <div class="example" data-use-content="true" data-class="image" data-tag="img">
     <h4 class="ui header">Image</h4>
     <p>A label can include an image</p>

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -239,6 +239,26 @@ themes      : ['Default', 'GitHub']
       </div>
     </div>
   </div>
+  <div class="another example">
+    <div class="ui two column grid">
+      <div class="column">
+        <div class="ui fluid image">
+          <div class="ui black ribbon icon label">
+            <i class="hotel icon"></i> 
+          </div>
+          <img src="/images/wireframe/image.png">
+        </div>
+      </div>
+      <div class="column">
+        <div class="ui fluid image">
+          <div class="ui blue right ribbon icon label">
+            <i class="spoon icon"></i>
+          </div>
+          <img src="/images/wireframe/image.png">
+        </div>
+      </div>
+    </div>
+  </div>
 
   <div class="clearing example">
     <h4 class="ui header">Attached</h4>

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -427,18 +427,15 @@ themes      : ['Default', 'GitHub']
   </div>
 
   <div class="another example" data-use-content="true">
-    <div class="ignored ui icon warning message">
-      <i class="warning sign icon"></i>
-      <div class="content">
-        For backward-compatibility during v2.x, <code>close</code>/<code>delete</code> icon...
+    <div class="ignored ui warning message">
+      For backward-compatibility during v2.x, <code>close</code>/<code>delete</code> icon...
       
-        <ul>
-          <li>requires <code>left icon</code> added to parent <code>label</code> when the icon is placed in the left of label.</li>
-          <li>do not require <code>right icon</code> added to parent <code>label</code> when the icon is placed in the right of label.</li>
-        </ul>
+      <ul>
+        <li>requires <code>left icon</code> added to parent <code>label</code> when the icon is placed in the left of label.</li>
+        <li>do not require <code>right icon</code> added to parent <code>label</code> when the icon is placed in the right of label.</li>
+      </ul>
       
-        This complicated rule may be simplified in v3.x.
-      </div>
+      This rule may be simplified in a later minor or major version".
     </div>
 
     <div class="ui left icon label">

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -211,8 +211,28 @@ themes      : ['Default', 'GitHub']
       </div>
       <div class="column">
         <div class="ui fluid image">
-          <div class="ui blue ribbon label">
+          <div class="ui blue right ribbon label">
             <i class="spoon icon"></i> Food
+          </div>
+          <img src="/images/wireframe/image.png">
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="another example">
+    <div class="ui two column grid">
+      <div class="column">
+        <div class="ui fluid image">
+          <div class="ui black ribbon right icon label">
+            Hotel <i class="hotel icon"></i> 
+          </div>
+          <img src="/images/wireframe/image.png">
+        </div>
+      </div>
+      <div class="column">
+        <div class="ui fluid image">
+          <div class="ui blue right ribbon right icon label">
+            Food <i class="spoon icon"></i>
           </div>
           <img src="/images/wireframe/image.png">
         </div>

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -333,16 +333,89 @@ themes      : ['Default', 'GitHub']
   <div class="example" data-use-content="true" data-class="icon">
     <h4 class="ui header">Icon</h4>
     <p>A label can include an icon</p>
-    <a class="ui label">
+    <div class="ui label">
       <i class="mail icon"></i>
       Mail
-    </a>
-    <a class="ui label">
-      Tag
-      <i class="delete icon"></i>
-    </a>
+    </div>
+    <div class="ui label">
+      <i class="checkmark icon"></i>
+      Test
+    </div>
+    <div class="ui label">
+      <i class="dog icon"></i>
+      Dog
+    </div>
+    <div class="ui label">
+      <i class="cat icon"></i>
+      Cat
+    </div>
+  </div>
+  
+  <div class="another example" data-use-content="true">
+    <div class="ignored ui info message">Icons can be placed in the right side of label.</div>
+
+    <div class="ui right icon label">
+      Mail
+      <i class="mail icon"></i>
+    </div>
+    <div class="ui right icon label">
+      Test
+      <i class="checkmark icon"></i>
+    </div>
+    <div class="ui right icon label">
+      Dog
+      <i class="dog icon"></i>
+    </div>
+    <div class="ui right icon label">
+      Cat
+      <i class="cat icon"></i>
+    </div>
   </div>
 
+  <div class="another example" data-use-content="true">
+    <div class="ignored ui info message">Icons can be hoverable to indicate an action.</div>
+    <div class="ui label">
+      <i class="hoverable mail icon"></i>
+      Mail
+    </div>
+    <div class="ui label">
+      <i class="hoverable close icon"></i>
+      Close
+    </div>
+    <div class="ui label">
+      <i class="hoverable delete icon"></i>
+      Delete
+    </div>
+
+    <div class="ui right icon label">
+      Mail
+      <i class="hoverable mail icon"></i>
+    </div>
+    <div class="ui right icon label">
+      Close
+      <i class="hoverable close icon"></i>
+    </div>
+    <div class="ui right icon label">
+      Delete
+      <i class="hoverable delete icon"></i>
+    </div>
+  </div>
+
+  <div class="another example">
+    <div class="ignored ui info message">Label can contains icon without text.</div>
+
+    <div class="ui icon label">
+      <i class="mail icon"></i>
+    </div>
+    <div class="ui icon label">
+      <i class="dog icon"></i>
+    </div>
+    <div class="ui icon label">
+      <i class="cat icon"></i>
+    </div>
+  </div>
+  
+  
   <div class="example" data-use-content="true" data-class="image" data-tag="img">
     <h4 class="ui header">Image</h4>
     <p>A label can include an image</p>

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -392,7 +392,7 @@ themes      : ['Default', 'GitHub']
   </div>
   
   <div class="another example" data-use-content="true">
-    <div class="ignored ui info message">Icons can be placed in the right side of label.</div>
+    <div class="ignored ui info message">Icons can be placed to the right inside a label.</div>
 
     <div class="ui right icon label">
       Mail
@@ -413,7 +413,7 @@ themes      : ['Default', 'GitHub']
   </div>
 
   <div class="another example">
-    <div class="ignored ui info message">Label can contains icon without text.</div>
+    <div class="ignored ui info message">Labels can contain individual icons without text.</div>
 
     <div class="ui icon label">
       <i class="mail icon"></i>
@@ -428,14 +428,14 @@ themes      : ['Default', 'GitHub']
 
   <div class="another example" data-use-content="true">
     <div class="ignored ui warning message">
-      For backward-compatibility during v2.x, <code>close</code>/<code>delete</code> icon...
+      For backward-compatibility during v2.x, <code>close</code>/<code>delete</code> icon.
       
       <ul>
-        <li>requires <code>left icon</code> added to parent <code>label</code> when the icon is placed in the left of label.</li>
-        <li>do not require <code>right icon</code> added to parent <code>label</code> when the icon is placed in the right of label.</li>
+        <li>Requires <code>left icon</code> to be added to the parent <code>label</code> when the icon is placed on the left of a label.</li>
+        <li>Does not require <code>right icon</code> to be added to parent <code>label</code> when the icon is placed on the right of the label.</li>
       </ul>
       
-      This rule may be simplified in a later minor or major version".
+      This rule may be simplified in a later minor or major version.
     </div>
 
     <div class="ui left icon label">

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -392,27 +392,6 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="another example" data-use-content="true">
-    <div class="ignored ui info message">Icons can be hoverable to indicate an action.</div>
-    <div class="ui label">
-      <i class="hoverable mail icon"></i>
-      Mail
-    </div>
-    <div class="ui label">
-      <i class="hoverable times icon"></i>
-      Test Failed
-    </div>
-
-    <div class="ui right icon label">
-      Mail
-      <i class="hoverable mail icon"></i>
-    </div>
-    <div class="ui right icon label">
-      Test Failed
-      <i class="hoverable times icon"></i>
-    </div>
-  </div>
-
   <div class="another example">
     <div class="ignored ui info message">Label can contains icon without text.</div>
 
@@ -436,7 +415,6 @@ themes      : ['Default', 'GitHub']
         <ul>
           <li>requires <code>left icon</code> added to parent <code>label</code> when the icon is placed in the left of label.</li>
           <li>do not require <code>right icon</code> added to parent <code>label</code> when the icon is placed in the right of label.</li>
-          <li>have special style as same as <code>hoverable</code> variation when the icon is inside <code>label</code> which do not have <code>icon</code> class.</li>
         </ul>
       
         This complicated rule may be simplified in v3.x.
@@ -444,11 +422,11 @@ themes      : ['Default', 'GitHub']
     </div>
 
     <div class="ui left icon label">
-      <i class="hoverable close icon"></i>
+      <i class="close icon"></i>
       Close
     </div>
     <div class="ui left icon label">
-      <i class="hoverable delete icon"></i>
+      <i class="delete icon"></i>
       Delete
     </div>
 


### PR DESCRIPTION
Follow-up of https://github.com/fomantic/Fomantic-UI/pull/388

## Screenshot
### Normal Label
![right-icons](https://user-images.githubusercontent.com/127635/51081906-2f923400-173f-11e9-91b6-f5a3b41f3d25.gif)

### Ribbon Label
![image](https://user-images.githubusercontent.com/127635/51081918-581a2e00-173f-11e9-9915-e64f24d59824.png)