### PR TITLE
[Dropdown,Search] Added examples for dropdown and search option 'ignoreDiacritics' 

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -145,6 +145,54 @@ themes      : ['Default', 'GitHub', 'Material']
       </select>
     </div>
 
+    <div class="diacritics example">
+      <h4 class="ui header">
+        Search ignoring Diacritics
+        <div class="ui black label">New in 2.7.2</div>
+      </h4>
+      <p>A selection dropdown can allow a user to ignore all Diacritics while searching.</p>
+      <div class="ui search selection dropdown" id="diacriticsexample">
+        <input type="hidden" name="diacritics">
+        <i class="dropdown icon"></i>
+        <div class="default text">Search diacritics by only typing usual vowels</div>
+        <div class="menu">
+            <div class="item">André</div>
+            <div class="item">Bokmål</div>
+            <div class="item">café</div>
+            <div class="item">cafetería</div>
+            <div class="item">château</div>
+            <div class="item">décolleté</div>
+            <div class="item">Élysée</div>
+            <div class="item">Fräulein</div>
+            <div class="item">garçon</div>
+            <div class="item">háček</div>
+            <div class="item">inrō</div>
+            <div class="item">jūjutsu</div>
+            <div class="item">kroužek</div>
+            <div class="item">La Niña</div>
+            <div class="item">Māori</div>
+            <div class="item">négligée</div>
+            <div class="item">pączki</div>
+            <div class="item">Québec</div>
+            <div class="item">ragoût</div>
+            <div class="item">Škoda</div>
+            <div class="item">takahē</div>
+            <div class="item">über</div>
+            <div class="item">voilà</div>
+            <div class="item">whekī</div>
+            <div class="item">c Zoë</div>
+        </div>
+      </div>
+      <div class="evaluated code" data-type="javascript">
+      $('#diacriticsexample')
+        .dropdown({
+          ignoreDiacritics: true,
+          sortSelect: true,
+          fullTextSearch:'exact'
+        });
+      </div>
+    </div>
+
     <div class="dropdown example">
       <h4 class="ui header">
         Clearable Selection
@@ -2926,6 +2974,12 @@ themes      : ['Default', 'GitHub', 'Material']
               </div>
             </div>
           </td>
+        </tr>
+        <tr>
+          <td>ignoreDiacritics</td>
+          <td>false</td>
+          <td>When activated, searches will also match results for base diacritic letters. For example when searching for 'a', it will also match 'á' or 'â' or 'å' and so on...
+              It will also ignore diacritics for the searchterm, so if searching for 'ó', it will match 'ó', but also 'o', 'ô' or 'õ' and so on...<div class="ui black label">New in 2.7.2</div><div class="ui red label">Not available in IE</div></td>
         </tr>
       </tbody>
     </table>

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -151,6 +151,9 @@ themes      : ['Default', 'GitHub', 'Material']
         <div class="ui black label">New in 2.7.2</div>
       </h4>
       <p>A selection dropdown can allow a user to ignore all Diacritics while searching.</p>
+      <div class="ui ignored info message">
+        If you want to support IE using the <code>ignoreDiacritics</code> option, you have to include a polyfill for the   <code>String().normalize()</code> method like <a href="https://cdn.jsdelivr.net/npm/unorm@1.4.1/lib/unorm.min.js">unorm</a>.
+      </div>
       <div class="ui search selection dropdown" id="diacriticsexample">
         <input type="hidden" name="diacritics">
         <i class="dropdown icon"></i>

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -152,6 +152,59 @@ type        : 'UI Module'
       </div>
     </div>
 
+    <div class="diacritics example">
+      <h4 class="ui header">
+        Search ignoring Diacritics
+        <div class="ui black label">New in 2.7.2</div>
+      </h4>
+      <p>A selection dropdown can allow a user to ignore all Diacritics while searching.</p>
+      <div class="ui search">
+        <div class="ui icon input">
+          <input class="prompt" type="text" placeholder="Search Diacritics...">
+          <i class="search icon"></i>
+        </div>
+        <div class="results"></div>
+      </div>
+      <div class="evaluated code" data-type="javascript">
+        $('#diacriticsexample')
+            .search({
+                ignoreDiacritics: true,
+                fullTextSearch:'exact',
+                source: diacriticsContent
+            })
+        ;
+      </div>
+      <div class="hidden code" data-type="javascript">
+      var diacriticsContent = [
+            { title: 'André'},
+            { title: 'Bokmål'},
+            { title: 'café'},
+            { title: 'cafetería'},
+            { title: 'château'},
+            { title: 'décolleté'},
+            { title: 'Élysée'},
+            { title: 'Fräulein'},
+            { title: 'garçon'},
+            { title: 'háček'},
+            { title: 'inrō'},
+            { title: 'jūjutsu'},
+            { title: 'kroužek'},
+            { title: 'La Niña'},
+            { title: 'Māori'},
+            { title: 'négligée'},
+            { title: 'pączki'},
+            { title: 'Québec'},
+            { title: 'ragoût'},
+            { title: 'Škoda'},
+            { title: 'takahē'},
+            { title: 'über'},
+            { title: 'voilà'},
+            { title: 'whekī'},
+            { title: 'c Zoë'}
+        ];
+      </div>
+    </div>
+
     <!-- Coming in 2.2
 
     <div class="local example">
@@ -767,6 +820,12 @@ type        : 'UI Module'
             easeOutExpo
           </td>
           <td>Easing equation when using fallback Javascript animation</td>
+        </tr>
+        <tr>
+          <td>ignoreDiacritics</td>
+          <td>false</td>
+          <td>When activated, searches will also match results for base diacritic letters. For example when searching for 'a', it will also match 'á' or 'â' or 'å' and so on...
+              It will also ignore diacritics for the searchterm, so if searching for 'ó', it will match 'ó', but also 'o', 'ô' or 'õ' and so on...<div class="ui black label">New in 2.7.2</div><div class="ui red label">Not available in IE</div></td>
         </tr>
       </tbody>
     </table>

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -158,6 +158,9 @@ type        : 'UI Module'
         <div class="ui black label">New in 2.7.2</div>
       </h4>
       <p>A selection dropdown can allow a user to ignore all Diacritics while searching.</p>
+      <div class="ui ignored info message">
+          If you want to support IE using the <code>ignoreDiacritics</code> option, you have to include a polyfill for the   <code>String().normalize()</code> method like <a href="https://cdn.jsdelivr.net/npm/unorm@1.4.1/lib/unorm.min.js">unorm</a>.
+      </div>
       <div class="ui search">
         <div class="ui icon input">
           <input class="prompt" type="text" placeholder="Search Diacritics...">


### PR DESCRIPTION
## Description
Added examples for dropdown and search option `ignoreDiacritics`  as of https://github.com/fomantic/Fomantic-UI/pull/422

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/51875017-7b5df380-2363-11e9-8a23-8978b2854ba3.png)

![image](https://user-images.githubusercontent.com/18379884/51874977-64b79c80-2363-11e9-8dd5-8b96298e3ae4.png)

![diac_settings](https://user-images.githubusercontent.com/18379884/51874495-7ac45d80-2361-11e9-9f83-8fa535eb216b.PNG)
