### PR TITLE
[Modal] Missing settings documented

### DIFF
--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -906,6 +906,21 @@ themes      : ['Default', 'Material']
           <td>If set to true will not close other visible modals when opening a new one</td>
         </tr>
         <tr>
+          <td>inverted</td>
+          <td>false</td>
+          <td>If inverted dimmer should be used</td>
+        </tr>
+        <tr>
+          <td>blurring</td>
+          <td>false</td>
+          <td>If dimmer should blur background</td>
+        </tr>
+        <tr>
+          <td>centered</td>
+          <td>true</td>
+          <td>If modal should be center aligned</td>
+        </tr>
+        <tr>
           <td>keyboardShortcuts</td>
           <td>true</td>
           <td>Whether to automatically bind keyboard shortcuts</td>


### PR DESCRIPTION
## Description
OPtions `inverted`, `blurring` and `centered` were not documented on the modals settings page. Added them

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/53306466-b0d7fd00-388d-11e9-9d06-cc337d26b4cd.png)

## Closes
https://github.com/fomantic/Fomantic-UI/issues/515
