### PR TITLE
[Modal] overlay fullscreen modal example

### DIFF
--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -196,6 +196,24 @@ themes      : ['Default', 'Material']
     </div>
   </div>
 
+  <div class="ui overlay fullscreen modal">
+    <div class="header">
+        Welcome to the <span class="ui teal text">overlay fullscreen modal</span>
+    </div>
+    <div class="content">
+        <div class="description">
+            <div class="ui header">Even if there is not much content here...</div>
+            ...the overlay fullscreen modal will occupy the entire screen
+        </div>
+    </div>
+    <div class="actions">
+        <div class="ui primary approve button">
+            Proceed
+            <i class="right chevron icon"></i>
+        </div>
+    </div>
+  </div>
+
   <div class="ui large test modal">
     <div class="header">
       Changing Your Thing
@@ -501,6 +519,20 @@ themes      : ['Default', 'Material']
       ;
       </div>
     </div>
+    <div class="no example">
+      <h4 class="ui header">Overlay Full Screen</h4>
+      <p>A modal can overlay the entire screen</p>
+      <div class="ui ignored info message">
+          Overlay fullscreen modals cannot be closed by clicking into the dimmer, because the dimmer is completely overlayed and not visible anymore).
+          Make sure your modal is closable by either adding a close icon or an action button to close it.
+      </div>
+      <div class="code" data-demo="true">
+      $('.overlay.fullscreen.modal')
+      .modal('show')
+      ;
+      </div>
+    </div>
+
     <div class="no example">
       <h4 class="ui header">Size</h4>
       <p>A modal can vary in size</p>


### PR DESCRIPTION
## Description
Added Example for `overlay fullscreen modal` as of https://github.com/fomantic/Fomantic-UI/pull/526

## Screenshot
![overlayfullscreenmodaldocs](https://user-images.githubusercontent.com/18379884/53496182-be65d080-3aa1-11e9-830b-09fae02929ea.gif)
