### PR TITLE
[Modal] Normal fullscreen example was opening new overlay example aswell

### DIFF
--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -513,7 +513,7 @@ themes      : ['Default', 'Material']
     <div class="no example">
       <h4 class="ui header">Full Screen</h4>
       <p>A modal can use the entire size of the screen</p>
-      <div class="code" data-demo="true">
+      <div class="code" data-demo="true" data-eval="$('.fullscreen.modal').not('.overlay').modal('show')">
       $('.fullscreen.modal')
         .modal('show')
       ;


### PR DESCRIPTION
## Description
The new overlay fullscreen example was also opened when the normal fullscreen example was called 🙄 