### PR TITLE
Fixed wrong red color on the hex description

### DIFF
--- a/server/documents/usage/theming.html.eco
+++ b/server/documents/usage/theming.html.eco
@@ -78,7 +78,7 @@ type        : 'Usage'
     <div class="ui ignored code" data-type="less" data-less="true" data-title="site/globals/site.variables">
     @primaryColor   : @pink;
     @secondaryColor : @grey;
-    @red            : #B03060;
+    @red            : #DB2828;
     @orange         : #FE9A76;
     @yellow         : #FFD700;
     @olive          : #32CD32;


### PR DESCRIPTION
The color on the docs describing the red color as hex number was wrong.