### PR TITLE
[Calendar] Added weekCell setting

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -845,6 +845,7 @@ themes      : ['Default']
               link: 'link',
               cell: 'link',
               disabledCell: 'disabled',
+              weekCell: 'disabled',
               adjacentCell: 'adjacent',
               activeCell: 'active',
               rangeCell: 'range',


### PR DESCRIPTION
## Description
Added the new `weekCell` classname
> According to the related PR, the default name is still `disabled` to keep previous behavior. Just in case you might think it's a copy/paste issue 😉 

## Related
https://github.com/fomantic/Fomantic-UI/pull/560