### PR TITLE
[Dropdown] Add examples of columnar dropdown menu.

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -1194,7 +1194,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <div class="item" data-value="0">Female</div>
         </div>
       </div>
-      
+
     </div>
 
     <div class="dropdown example">
@@ -1408,6 +1408,44 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
+    <div class="dropdown example">
+      <h4 class="ui header">Columnar Menu</h4>
+      <p>A selection dropdown can allow menu to be equally divided so that more items can be glanced.</p>
+      <select class="ui two column dropdown" multiple>
+        <option value="1">one</option>
+        <option value="2">two</option>
+        <option value="3">three</option>
+        <option value="4">four</option>
+        <option value="5">five</option>
+        <option value="6">six</option>
+        <option value="7">seven</option>
+        <option value="8">eight</option>
+        <option value="9">nine</option>
+        <option value="10">ten</option>
+        <option value="0">zero</option>
+      </select>
+    </div>
+
+    <div class="another dropdown example">
+      <p>Three columns.</p>
+      <select class="ui fluid search three column dropdown" multiple>
+        <%- @partial('examples/single/state-options') %>
+      </select>
+    </div>
+
+    <div class="another dropdown example">
+      <p>Four columns.</p>
+      <select class="ui fluid search four column dropdown" multiple>
+        <%- @partial('examples/single/state-options') %>
+      </select>
+    </div>
+
+    <div class="another dropdown example">
+      <p>Five columns.</p>
+      <select class="ui fluid search five column dropdown" multiple>
+        <%- @partial('examples/single/state-options') %>
+      </select>
+    </div>
   </div>
 
 


### PR DESCRIPTION
Add new content for columnar dropdown proposed in https://github.com/fomantic/Fomantic-UI/pull/586

## Screenshot (when possible)
### Standard dropdown of 2 columns
![standard-two-col](https://user-images.githubusercontent.com/127635/54887966-f236e900-4edb-11e9-8236-d89b24a9d5dd.gif)

### Fluid search dropdown of 3 columns
![fluid-search-three-col](https://user-images.githubusercontent.com/127635/54887963-ea774480-4edb-11e9-8812-52c2e30e0392.gif)
