### PR TITLE
fix(modal): inverted dimmer example showed two modals

### DIFF
--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -799,7 +799,7 @@ themes      : ['Default', 'Material']
       <h4 class="ui header">Dimmer Variations</h4>
       <p>Modals can specify additional variations like <code>blurring</code> or <code>inverted</code> which adjust how the dimmer displays.</p>
       <div class="ui ignored info message">Full screen blurring modals are not performant for current-gen computers at widescreen resolutions with integrated graphics.</div>
-      <div class="code" data-demo="true" data-eval="$('.ui.inverted.modal').modal({inverted: true}).modal('show')">
+      <div class="code" data-demo="true" data-eval="$('.ui.inverted.modal').not('.mini').modal({inverted: true}).modal('show')">
       $('.ui.modal')
         .modal({
           inverted: true


### PR DESCRIPTION
## Description
The example using the inverted dimmer variant showed 2 modals instead of one

## Testcase
http://fomantic-ui.com/modules/modal.html#dimmer-variations

## Screenshot
![inverteddimmermodaltwice](https://user-images.githubusercontent.com/18379884/55481115-f83a7180-5621-11e9-8cee-159e3f09c9b1.gif)
