### PR TITLE
fix(calendar): missing closing brace in formatter example

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -279,11 +279,12 @@ themes      : ['Default']
           type: 'date',
           formatter: {
             date: function (date, settings) {
-            if (!date) return '';
-            var day = date.getDate();
-            var month = date.getMonth() + 1;
-            var year = date.getFullYear();
-            return day + '/' + month + '/' + year;
+              if (!date) return '';
+              var day = date.getDate();
+              var month = date.getMonth() + 1;
+              var year = date.getFullYear();
+              return day + '/' + month + '/' + year;
+            }
           }
         })
       ;


### PR DESCRIPTION
## Description
A closing brace was missing in the example for formatter setting

## Closes
https://github.com/fomantic/Fomantic-UI/issues/621
