### PR TITLE
[Reveal] right move was not bound to image dimensions so overflow:hidden was useless

### DIFF
--- a/server/documents/elements/reveal.html.eco
+++ b/server/documents/elements/reveal.html.eco
@@ -51,7 +51,7 @@ themes      : ['Default']
     </div>
   </div>
   <div class="another example">
-    <div class="ui move right reveal">
+    <div class="ui move right reveal small image">
       <div class="visible content">
         <img src="/images/wireframe/square-image.png" class="ui small image">
       </div>


### PR DESCRIPTION
## Description
The example for `move right reveal` was not hiding the "visible item" image when it moves away.
The dimensions were not set, so the div occupied the whole width which made the overflow: hidden (from reveal) usesless

## Testcase
https://fomantic-ui.com/elements/reveal.html
https://jsfiddle.net/moLtk1nx/

## Screenshot
|Before|After|
|-|-|
|![reveal_before](https://user-images.githubusercontent.com/18379884/56662751-f6a21d80-66a4-11e9-8159-94aea2c6e99e.gif)|![reveal_after](https://user-images.githubusercontent.com/18379884/56662761-fb66d180-66a4-11e9-814f-2285064bb2aa.gif)|

## Closes
https://github.com/fomantic/Fomantic-UI/issues/689