### PR TITLE
fix(dropdown): bottom pointing example didn't show on mobile

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -628,7 +628,7 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
     <div class="another button example">
-      <div class="ui labeled icon top right pointing dropdown button">
+      <div class="ui labeled icon top left pointing dropdown button">
         <i class="filter icon"></i>
         <span class="text">Filter Posts</span>
         <div class="menu">


### PR DESCRIPTION
## Description 
One example for bottom pointing menu was off canvas on mobile

## Screenshot
![](https://cloud.githubusercontent.com/assets/6639874/26513796/2ade26c0-4276-11e7-8a04-028142912211.png)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/5415