### PR TITLE
[Dropdown] Corrected old renamed behavior

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -2836,7 +2836,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>Unbinds document intent click</td>
         </tr>
         <tr>
-        <td>determine intent</td>
+        <td>determine eventInModule</td>
           <td>Returns whether event occurred inside dropdown</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Description
The function `determine intent` was renamed to `determine eventInModule` (by f56d41575ab01b20869c0cba0fb3890fa5260d39 and finally by f2d7d0c2446485d540b07b1d70154419bd1d34b6)in 2014, but never updated in the docs. This PR does it now

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/3540