### PR TITLE
feat(*): make headers visible anchors

### DIFF
--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -356,11 +356,14 @@ semantic.ready = function() {
             $title   = $(this).children('h4').eq(0),
             text     = handler.getText($title),
             safeName = handler.getSafeName(text),
-            id       = window.escape(safeName),
-            $anchor  = $('<a />').addClass('anchor').attr('id', id)
+            id       = window.escape(safeName)
           ;
-          if($title.length > 0) {
-            $title.after($anchor);
+          if ($title.length > 0 && id.length > 0) {
+            var $contentWrapped = $("<a/>").attr('href', '#' + id).html([
+              $('<i class="fitted small linkify icon"></i>'),
+              $title.html()
+            ]).on('click', handler.scrollTo);
+            $title.attr('id', id).html($contentWrapped);
           }
         })
       ;
@@ -399,7 +402,7 @@ semantic.ready = function() {
         html      = '',
         pageTitle = handler.getPageTitle(),
         title     = pageTitle.charAt(0).toUpperCase() + pageTitle.slice(1),
-        activeTab = handler.getActiveTabTitle(),  
+        activeTab = handler.getActiveTabTitle(),
         $sticky,
         $rail
       ;
@@ -495,7 +498,7 @@ semantic.ready = function() {
       var
         id       = $(this).attr('href').replace('#', ''),
         $element = $('#' + id),
-        position = $element.offset().top + 10
+        position = $element.offset().top - 10
       ;
       $element
         .addClass('active')

--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -727,7 +727,25 @@ blockquote .author {
 #example .example > h4:first-child {
   font-size: 18px;
   margin: 0em 0em 0em;
+  position: relative;
 }
+
+#example .example > h4 > a {
+  color: rgba(0, 0, 0, 0.87);
+}
+#example .example > h4 > a:hover {
+  color: rgba(0, 0, 0, 0.95);
+}
+#example .example > h4 > a > i.linkify.icon {
+  color: rgba(0, 0, 0, 0.25);
+  position: absolute;
+  left: -1.2rem;
+  line-height: 1.5em;
+}
+#example .example > h4 > a:hover > i.linkify.icon {
+  color: rgba(0, 0, 0, 0.75);
+}
+
 
 /* Wireframe Image */
 #example .example .wireframe.image {
@@ -912,6 +930,7 @@ blockquote .author {
 #example .another.example i.code {
   top: -0.5em;
 }
+
 
 /* Spaced */
 #example .spaced.example .buttons,


### PR DESCRIPTION
Example headers have hidden anchor that are available through TOC.

I frequently share the URLs of example to example with team.
To get URL, we need to click TOC.
I think it is more intuitive to click header itself to get URL.
And these headers have no visual appeal to indicate they have anchors.

So this PR 
* Adds `linkify` icon as visual appeal to example headers
* Make headers itself clickable so users can get URL to headers 

![anchor-to-example-header](https://user-images.githubusercontent.com/127635/57455958-56a0e280-72a7-11e9-8b4e-c7c73f405314.gif)
