### PR TITLE
Misswriting on dividing header

### DIFF
--- a/server/documents/modules/slider.html.eco
+++ b/server/documents/modules/slider.html.eco
@@ -221,7 +221,7 @@ themes      : ['Default']
 
   <div class="ui tab" data-tab="settings">
     <h2 class="ui dividing header">
-      Calendar
+      Slider
     </h2>
 
     <h4 class="ui header">


### PR DESCRIPTION
In Settings tabs of Slider Module, the header title its "Calendar"