### PR TITLE
fix(index): search wasn't visible when fixed at top while scrolling

### DIFF
--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -2070,6 +2070,16 @@ code .chunk {
   z-index: 6000 !important;
 }
 
+.fixed.following.bar #docs-searchbox input,
+.fixed.following.bar #docs-searchbox input::placeholder {
+  color: #000;
+}
+.fixed.following.bar #docs-searchbox:hover,
+.fixed.following.bar #docs-searchbox:focus-within {
+  color: #000;
+  background: rgba(0, 0, 0, 0.08);
+}
+
 /*******************************
       Definition Container
 *******************************/


### PR DESCRIPTION
## Description
The new searchbar on the frontpage gets invisible when the page is scrolled and the menu gets a white background

## Screenshot
### Before
![searchbar_bad](https://user-images.githubusercontent.com/18379884/57939825-6fbf1a00-78cb-11e9-9204-bf509c4d20df.gif)

### After
![searchbar_good](https://user-images.githubusercontent.com/18379884/57939844-78afeb80-78cb-11e9-801e-9ec8c416048c.gif)

