### PR TITLE
[Calendar] Typo Fix

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -769,7 +769,7 @@ themes      : ['Default']
         <tr>
           <td>disableMinute</td>
           <td>false</td>
-          <td>Fisable minute selection mode</td>
+          <td>Disable minute selection mode</td>
         </tr>
         <tr>
           <td>formatInput</td>


### PR DESCRIPTION
## Description
A small typo fix in calendar settings (`Fisable` -> `Disable`)

## Closes
https://github.com/fomantic/Fomantic-UI/issues/835