### PR TITLE
fix(api): added missing callback parameters in response example

### DIFF
--- a/server/documents/behaviors/api.html.eco
+++ b/server/documents/behaviors/api.html.eco
@@ -576,7 +576,7 @@ type        : 'UI Behavior'
             onSuccess: function(response, element, xhr) {
               // valid response and response.success = true
             },
-            onFailure: function(response, element) {
+            onFailure: function(response, element, xhr) {
               // request failed, or valid response but response.success = false
             },
             onError: function(errorMessage, element, xhr) {
@@ -1191,7 +1191,7 @@ type        : 'UI Behavior'
           <td>Callback on request complete regardless of conditions</td>
         </tr>
         <tr>
-          <td>onFailure(response, element)</td>
+          <td>onFailure(response, element, xhr)</td>
           <td>state context</td>
           <td>Callback on failed response, or JSON response that fails <code>successTest</code></td>
         </tr>

--- a/server/documents/behaviors/api.html.eco
+++ b/server/documents/behaviors/api.html.eco
@@ -570,19 +570,19 @@ type        : 'UI Behavior'
               // test whether a JSON response is valid
               return response.success || false;
             },
-            onComplete: function(response) {
+            onComplete: function(response, element, xhr) {
               // always called after XHR complete
             },
-            onSuccess: function(response) {
+            onSuccess: function(response, element, xhr) {
               // valid response and response.success = true
             },
-            onFailure: function(response) {
+            onFailure: function(response, element) {
               // request failed, or valid response but response.success = false
             },
-            onError: function(errorMessage) {
+            onError: function(errorMessage, element, xhr) {
               // invalid response
             },
-            onAbort: function(errorMessage) {
+            onAbort: function(errorMessage, element, xhr) {
               // navigated to a new page, CORS issue, or user canceled request
             }
           })


### PR DESCRIPTION
## Description
Adjusted missing callback parameters to server response example to match with settings entry and actual codebase

Adopted from https://github.com/Semantic-Org/Semantic-UI-Docs/pull/413
Thanks to @daveharris
