### PR TITLE
fix(message): Missing closing tag

### DIFF
--- a/server/documents/collections/message.html.eco
+++ b/server/documents/collections/message.html.eco
@@ -240,7 +240,7 @@ themes      : ['Default', 'GitHub', 'Gmail']
       <div class="header">
         We're sorry we can't apply that discount
       </div>
-      <p>That offer has expired
+      <p>That offer has expired</p>
     </div>
   </div>
   <div class="another example">


### PR DESCRIPTION
## Description
A paragraph in mesage was missing the closing tag

Adopted from https://github.com/Semantic-Org/Semantic-UI-Docs/pull/386
Thanks to @hisener

