### PR TITLE
[Calendar] type and date as data attributes example

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -141,8 +141,8 @@ themes      : ['Default']
       </div>
     </div>
     <div class="another example">
-      <p>You can also set the type or date using HTML markup <div class="ui black label">New in 2.8.0</div></p>
-      <div class="ui info message">This could be useful when used with form validation without the need to instantiate the calendar via javascript before. Form validation recognizes a calendar component within the form and instantiates it automatically by using existing metadata values.</div>
+      <p>You can also set the type or date using HTML markup <span class="ui black label">New in 2.8.0</span></p>
+      <div class="ui ignored info message">This could be useful when used with form validation without the need to instantiate the calendar via javascript before. Form validation recognizes a calendar component within the form and instantiates it automatically by using existing metadata values.</div>
       <div class="ui calendar" id="type_calendar" data-type="date" data-date="2019-12-24">
         <div class="ui input left icon">
           <i class="calendar icon"></i>

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -140,6 +140,16 @@ themes      : ['Default']
       ;
       </div>
     </div>
+    <div class="another example">
+      <p>You can also set the type or date using HTML markup <div class="ui black label">New in 2.8.0</div></p>
+      <div class="ui info message">This could be useful when used with form validation without the need to instantiate the calendar via javascript before. Form validation recognizes a calendar component within the form and instantiates it automatically by using existing metadata values.</div>
+      <div class="ui calendar" id="type_calendar" data-type="date" data-date="2019-12-24">
+        <div class="ui input left icon">
+          <i class="calendar icon"></i>
+          <input type="text" placeholder="Date">
+        </div>
+      </div>
+    </div>
 
     <div class="example">
       <h4 class="ui header">Year first calendar</h4>

--- a/server/files/javascript/calendar.js
+++ b/server/files/javascript/calendar.js
@@ -10,6 +10,8 @@ semantic.calendar.ready = function() {
     handler
   ;
 
+  //Type by data attribute
+  $('#type_calendar').calendar({});
   // Range
   $('#rangestart').calendar({
     type: 'date',


### PR DESCRIPTION
## Description
Added one example for usage of type and date as metadata 

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/67787938-b7002800-fa71-11e9-85bc-163333caa36e.png)

## Related to
https://github.com/fomantic/Fomantic-UI/pull/1093