### PR TITLE
[Calendar] Infos for new onBeforeChange andold onChange callbacks

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -595,7 +595,7 @@ themes      : ['Default']
       </tr>
       <tr>
         <td>set date(date, updateInput = true, fireChange = true)</td>
-        <td>Set the selected date. Pass <code>false</code> to <code>updateInput</code> to disable updating the input. Pass <code>false</code> to <code>fireChange</code> to disable the <code>onChange</code> callback for this change</td>
+        <td>Set the selected date. Pass <code>false</code> to <code>updateInput</code> to disable updating the input. Pass <code>false</code> to <code>fireChange</code> to disable the <code>onBeforeChange</code> and <code>onChange</code> callbacks for this change</td>
       </tr>
       <tr>
         <td>get mode</td>
@@ -853,10 +853,15 @@ themes      : ['Default']
         <th>Description</th>
       </thead>
       <tbody>
-      <tr>
+        <tr>
+          <td>onBeforeChange <span class="ui red label"><i class="exclamation icon"></i>New in 2.8.0</span></td>
+          <td>active content</td>
+          <td>Is called before a calendar date changes. <code>return false;</code> will cancel the change</td>
+        </tr>
+        <tr>
           <td>onChange</td>
           <td>active content</td>
-          <td>Is called after a calendar date changes. <code>return false;</code> will cancel the change</td>
+          <td>Is called after a calendar date has changed.</td>
         </tr>
         <tr>
           <td>onShow</td>


### PR DESCRIPTION
## Description
Change infos to new `onBeforeChange` and old `onChange` callback as of  https://github.com/fomantic/Fomantic-UI/pull/982

> I added a prominent red exclamation mark because this is a breaking change (Users have to change their current onChange usages to onBeforeChange to gain the same effect as before

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/67805982-5503ea80-fa92-11e9-9a63-7fdff653d83a.png)
