### PR TITLE
feat(calendar): added missing append selector and short info about usage

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -893,7 +893,7 @@ themes      : ['Default']
     <table class="ui sortable celled definition table">
       <thead>
         <th>Setting</th>
-        <th class="six wide">Default</th>
+        <th class="seven wide">Default</th>
         <th>Description</th>
       </thead>
       <tbody>
@@ -909,15 +909,17 @@ themes      : ['Default']
         </tr>
         <tr>
           <td>selector</td>
-          <td colspan="2">
+          <td>
             <div class="code" data-type="css">
             selector    : {
               popup: '.ui.popup',
               input: 'input',
-              activator: 'input'
+              activator: 'input',
+              append: '.inline.field,.inline.fields'
             }
             </div>
           </td>
+          <td>If the calendars parent node matches the <code>append</code> selector, the calendar is appended to the input field instead of prepended.</td>
         </tr>
         <tr>
           <td>className</td>


### PR DESCRIPTION
## Description
Added missing `append` selector, which was invented by https://github.com/fomantic/Fomantic-UI/pull/752 ,  and a short info about its usage

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/68132011-45672480-ff1e-11e9-9834-2dd955a64b23.png)

## Related
https://github.com/fomantic/Fomantic-UI/issues/1146