### PR TITLE
fix(popup): star icons were missing in predefinded html example

### DIFF
--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -50,7 +50,7 @@ themes      : ['Default']
       <h4 class="ui header">HTML</h4>
       <p>An element can specify HTML for a popup</p>
 
-      <div class="ui card" data-html="<div class='header'>User Rating</div><div class='content'><div class='ui yellow rating'><i class='active icon'></i><i class='active icon'></i><i class='active icon'></i><i class='active icon'></i><i class='active icon'></i></div></div>">
+      <div class="ui card" data-html="<div class='header'>User Rating</div><div class='content'><div class='ui yellow rating'><i class='active star icon'></i><i class='active star icon'></i><i class='active star icon'></i><i class='active star icon'></i><i class='active star icon'></i></div></div>">
         <div class="image">
           <img src="/images/movies/totoro-horizontal.jpg">
         </div>


### PR DESCRIPTION
## Description

The popup example with predefeined HTML missed the rating star icons

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/70417869-72997c00-1a62-11ea-9444-bcd91d4a2f22.png)

## Closes
#185 