### PR TITLE
Fixed example for grid alignment

### DIFF
--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -373,7 +373,7 @@ themes      : ['Default']
         </div>
         <div class="right aligned sixteen wide column">
           <div class="ui segment">
-            Right Aligned Grid
+            Right Aligned Column
           </div>
         </div>
       </div>

--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -371,7 +371,7 @@ themes      : ['Default']
             </div>
           </div>
         </div>
-        <div class="sixteen wide column">
+        <div class="right aligned sixteen wide column">
           <div class="ui segment">
             Right Aligned Grid
           </div>

--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -348,7 +348,7 @@ themes      : ['Default']
       <p>Grids include many variations for adjusting things like vertical or horizontal alignment, text alignment, or default gutter sizes.</p>
       <p>Some multi-word variations, like <a href="#floated"><code>left floated</code></a> or <a href="#text-alignment"><code>right aligned</code></a> are word-order dependent and require you to use adjacent class names.</p>
 
-      <div class="ui right aligned grid">
+      <div class="ui aligned grid">
         <div class="left floated right aligned six wide column">
           <div class="ui segment">
             Left floated right aligned column


### PR DESCRIPTION
Grid alignment example have wrong class set for container, so originally it looked like this:
![Screen Shot 2020-01-08 at 17 07 59](https://user-images.githubusercontent.com/108335/71984481-f8633f80-3239-11ea-9de5-da4f59459b61.png)
