### PR TITLE
[Modal] Added info about "inside" class for close icons

### DIFF
--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -856,6 +856,11 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
+    <div class="ui info message">
+        Usually a given close icon on smaller modals will be displayed outside of the modal.
+        You can force to display the close icon inside the modal, just like in fullscreen modals, by adding the <code>inside</code> class to the close icon.
+    </div>
+
     <h2 class="ui dividing header">Behavior</h2>
 
     <p>All the following behaviors can be called using the syntax:</p>


### PR DESCRIPTION
## Description
Added info about the optional `inside` class for the close icon of modals according to https://github.com/fomantic/Fomantic-UI/pull/1215

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/73642847-b976ad00-4672-11ea-8462-6c16412a040e.png)
