### PR TITLE
fix(segment): wrap vertical segment example into a separate div to make first-child work

### DIFF
--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -132,14 +132,16 @@ themes      : ['default', 'GitHub']
   <div class="example">
     <h4 class="ui header">Vertical Segment</h4>
     <p>A vertical segment formats content to be aligned as part of a vertical group</p>
-    <div class="ui vertical segment">
-      <img class="ui wireframe image" src="/images/wireframe/short-paragraph.png">
-    </div>
-    <div class="ui vertical segment">
-      <img class="ui wireframe image" src="/images/wireframe/short-paragraph.png">
-    </div>
-    <div class="ui vertical segment">
-      <img class="ui wireframe image" src="/images/wireframe/short-paragraph.png">
+    <div>
+      <div class="ui vertical segment">
+        <img class="ui wireframe image" src="/images/wireframe/short-paragraph.png">
+      </div>
+      <div class="ui vertical segment">
+        <img class="ui wireframe image" src="/images/wireframe/short-paragraph.png">
+      </div>
+      <div class="ui vertical segment">
+        <img class="ui wireframe image" src="/images/wireframe/short-paragraph.png">
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Description
The `vertical segment` example won't work anymore when  https://github.com/fomantic/Fomantic-UI/pull/1416 will be applied.
Basically the current example is , even without the mentioned PR, only working by accident. whenever an additional div would have been added underneath the vertical segment it wouldnt have worked anymore also.
This PR just wraps the example segments into a separate div, so the `first-child` selector will correctly work (and remove the most upper border again)

Visually this PR otherwise does not make any difference at all.