### PR TITLE
fix(calendar): reflect the changes to the calendar module

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -739,7 +739,7 @@ themes      : ['Default']
         <tr>
           <td>on</td>
           <td>null</td>
-          <td>Choose when to show the popup (defaults to <code>focus</code> for input, <code>click</code> for others)</td>
+          <td>Choose when to show the popup (defaults to <code>click</code>)</td>
         </tr>
         <tr>
           <td>initialDate</td>


### PR DESCRIPTION
With the removal of superfluous event listeners on the calendar module, the popup will not act as described before. To reflect the docs better, the calendar module should be triggered by click events by default.

This reflects the changes done in fomantic/Fomantic-UI#1439, fomantic/Fomantic-UI#1508 and fomantic/Fomantic-UI#1509