### PR TITLE
feat(rating): added example without using javascript

### DIFF
--- a/server/documents/modules/rating.html.eco
+++ b/server/documents/modules/rating.html.eco
@@ -253,7 +253,7 @@ themes      : ['Default']
 
     <div class="example">
       <h4 class="ui header">Without Javascript</h4>
-      <p>If you don't need user interaction, you can use the rating module as a pure readonly CSS element</p>
+      <p>If you don't need user interaction, you can use the rating module as a pure read-only CSS element</p>
       <div class="code" data-type="html">
         <div class="ui red rating disabled">
           <i class="heart icon active"></i>

--- a/server/documents/modules/rating.html.eco
+++ b/server/documents/modules/rating.html.eco
@@ -251,6 +251,20 @@ themes      : ['Default']
       </div>
     </div>
 
+    <div class="example">
+      <h4 class="ui header">Without Javascript</h4>
+      <p>If you don't need user interaction, you can use the rating module as a pure readonly CSS element</p>
+      <div class="code" data-type="html">
+        <div class="ui red rating disabled">
+          <i class="heart icon active"></i>
+          <i class="heart icon active"></i>
+          <i class="heart icon active"></i>
+          <i class="heart icon"></i>
+          <i class="heart icon"></i>
+        </div>
+      </div>
+    </div>
+
     <h2 class="ui dividing header">Behaviors</h2>
 
     <p>All the following behaviors can be called using the syntax:</p>


### PR DESCRIPTION
## Description

This PR adds an example for using the rating module as a pure CSS only element, when no interaction is desired, thus no javascript is needed. 

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/85928026-459ba200-b8aa-11ea-9348-2495c80f0287.png)
