### PR TITLE
fix(checkbox) Changed disabled description

### DIFF
--- a/server/documents/modules/checkbox.html.eco
+++ b/server/documents/modules/checkbox.html.eco
@@ -194,7 +194,7 @@ themes      : ['Default', 'Colored']
 
     <div class="example">
       <h4 class="ui header">Disabled</h4>
-      <p>A checkbox can be read-only and unable to change states</p>
+      <p>A checkbox can show it is currently unable to be interacted with</p>
       <div class="ui ignored info message">
         A checkbox can be disabled by either setting the disabled attribute on the hidden input, or class <code>disabled</code> on the <code>ui checkbox</code>
       </div>


### PR DESCRIPTION
## Description
Disabled checkbox has the same description as read-only checkbox
Copying descriptions for snippets saw this 😄.

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/23702867/88152070-caf14880-cc03-11ea-9b2a-0207b49210e9.png)

### After
![image](https://user-images.githubusercontent.com/23702867/88151916-954c5f80-cc03-11ea-804e-2de62b4652db.png)

P.S. Correct folder? 🙄