### PR TITLE
[Dropdown] vertical item example

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -906,7 +906,31 @@ themes      : ['Default', 'GitHub', 'Material']
         </div>
       </div>
     </div>
-
+    <div class="dropdown example">
+      <p>The description can be shown vertically underneath the entry using <code>vertical item</code>.</p>
+      <div class="ui floating labeled icon dropdown button">
+        <i class="filter icon"></i>
+        <span class="text">Filter Tags</span>
+        <div class="menu">
+          <div class="header">
+            Filter by tag
+          </div>
+          <div class="divider"></div>
+          <div class="vertical item">
+            <span class="description">2 new</span>
+            <span class="text">Important</span>
+          </div>
+          <div class="vertical item">
+            <span class="description">10 new</span>
+            <span class="text">Hopper</span>
+          </div>
+          <div class="vertical item">
+            <span class="description">5 new</span>
+            <span class="text">Discussion</span>
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="dropdown example">
       <h4 class="ui header">Label</h4>
       <p>A dropdown menu can contain a <a href="/elements/label.html">label</a>.</p>


### PR DESCRIPTION
## Description
Added example for the optional `vertical item` of a dropdown description entry as of https://github.com/fomantic/Fomantic-UI/pull/1116

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/92300651-d05ce500-ef5c-11ea-9afa-46b660ee3813.png)
