### PR TITLE
fix(jsfiddle): support dashes and underscores in jsfiddle usernames

### DIFF
--- a/server/raw/jsfiddle/index.html
+++ b/server/raw/jsfiddle/index.html
@@ -38,7 +38,7 @@
 <script>
     var jsfiddleInfo = window.location.href.split("#!");
     if(jsfiddleInfo.length > 1){
-        var orgFiddle = '//jsfiddle.net/'+jsfiddleInfo[1].replace(/[^a-zA-Z0-9\/]/g,'');
+        var orgFiddle = '//jsfiddle.net/'+jsfiddleInfo[1].replace(/[^a-zA-Z0-9\/\-_]/g,'');
         document.getElementById('jsfiddle').src = orgFiddle+'/embedded/result/';
         document.getElementById('orgfiddle').href = orgFiddle;
     }


### PR DESCRIPTION
## Description
While the jsfiddle codes do only consist of numbers and characters, a possible given jsfiddle username infront of the jsfiddle link may contain dashes or underscores, which where removed and thus makes given jsfiddle links not working anymore