### PR TITLE
fix(input): typo error

### DIFF
--- a/server/documents/elements/input.html.eco
+++ b/server/documents/elements/input.html.eco
@@ -353,7 +353,7 @@ themes      : ['Default', 'GitHub']
         Textarea
         <div class="ui black label">New in 2.7</div>
     </h4>
-    <p>Using the input class you can also use some features on <code>textarea</code> aswell</p>
+    <p>Using the input class you can also use some features on <code>textarea</code> as well</p>
     <div class="ui form">
         <div class="ui left corner labeled input">
             <div class="ui left corner label">


### PR DESCRIPTION
Fix the typo error `aswell` which should be `as well`.

## Before
![TypoError](https://user-images.githubusercontent.com/930315/92973693-b6fef000-f4aa-11ea-93b6-528f68df5919.png)

## After
![TypoCorrected](https://user-images.githubusercontent.com/930315/92973681-b0707880-f4aa-11ea-8399-c2b0408ef297.png)