### PR TITLE
feat(slider): bottom aligned label

### DIFF
--- a/server/documents/modules/slider.html.eco
+++ b/server/documents/modules/slider.html.eco
@@ -48,6 +48,12 @@ themes      : ['Default']
     </div>
 
     <div class="example">
+        <h4 class="ui header">Label at the bottom</h4>
+        <p>A slider can display the labels below the track</p>
+        <div class="ui bottom aligned labeled slider"></div>
+    </div>
+
+    <div class="example">
         <h4 class="ui header">Custom interpreted labels</h4>
         <p>You can provide a function which returns a custom label according to the label value</p>
         <div class="ui labeled ticked slider" id="interpretedlabel"></div>


### PR DESCRIPTION
Add the bottom aligned label example ([Fomantic-UI/pull/1631](https://github.com/fomantic/Fomantic-UI/pull/1631)).