### PR TITLE
fix(dropdown): incorrect format in example code of selector settings

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -3629,7 +3629,7 @@ themes      : ['Default', 'GitHub', 'Material']
         <tr>
           <td>selector</td>
           <td colspan="2">
-            <div class="code" data-type="html">
+            <div class="code" data-type="css">
             selector : {
               addition     : '.addition',
               divider      : '.divider, .header',


### PR DESCRIPTION
The child combinator syntax `>` is encoded in the example of selector settings and it's not readable for the user. The syntax is encoded into HTML character as `&gt;` because the example code block is formatted as HTML code block via `data-type=html`.

The selector settings is for CSS and so it's formatted as CSS code block by changing `data-type=css`.

**Before:**
![IncorrectFormat](https://user-images.githubusercontent.com/930315/99911158-d6bf5980-2d20-11eb-8b22-f95c5bc198c9.png)

**After:**
![CorrectFormat](https://user-images.githubusercontent.com/930315/99911162-dc1ca400-2d20-11eb-8058-d56c0cd27205.png)