### PR TITLE
feat(card): disabled and loading card examples

### DIFF
--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -493,6 +493,89 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
 
   </div>
 
+  <h2 class="ui dividing header">States</h2>
+
+  <div class="example">
+    <h4 class="ui header">Disabled</h4>
+    <p>A card may show its content is disabled</p>
+    <div class="ui disabled card">
+        <div class="content">
+          <a class="header">Kristy</a>
+          <div class="meta">
+            <span class="date">Joined in 2013</span>
+          </div>
+          <div class="description">
+            Kristy is an art director living in New York.
+          </div>
+        </div>
+        <div class="extra content">
+          <a>
+            <i class="user icon"></i>
+            22 Friends
+          </a>
+        </div>
+    </div>
+  </div>
+  <div class="example">
+    <h4 class="ui header">Loading</h4>
+    <p>A card may show its content is being loaded</p>
+    <div class="ui loading card">
+        <div class="content">
+          <a class="header">Kristy</a>
+          <div class="meta">
+            <span class="date">Joined in 2013</span>
+          </div>
+          <div class="description">
+            Kristy is an art director living in New York.
+          </div>
+        </div>
+        <div class="extra content">
+          <a>
+            <i class="user icon"></i>
+            22 Friends
+          </a>
+        </div>
+    </div>
+  </div>
+  <div class="another example">
+    <p>The loader inherits the color of the card, if you want to prevent this, add the <code>usual</code> class, so the loader color stays default, while the card still gets its color</p>
+    <div class="ui ignored info message"><code>elastic</code> as loading style is currently not supported  because card uses the <code>:before</code> pseudoclass to dimm the background.</div>
+    <div class="ui brown double loading card">
+        <div class="content">
+          <a class="header">Kristy</a>
+          <div class="meta">
+            <span class="date">Joined in 2013</span>
+          </div>
+          <div class="description">
+            Kristy is an art director living in New York.
+          </div>
+        </div>
+        <div class="extra content">
+          <a>
+            <i class="user icon"></i>
+            22 Friends
+          </a>
+        </div>
+    </div>
+    <div class="ui brown usual double loading card">
+        <div class="content">
+          <a class="header">Kristy</a>
+          <div class="meta">
+            <span class="date">Joined in 2013</span>
+          </div>
+          <div class="description">
+            Kristy is an art director living in New York.
+          </div>
+        </div>
+        <div class="extra content">
+          <a>
+            <i class="user icon"></i>
+            22 Friends
+          </a>
+        </div>
+    </div>
+  </div>
+
   <h2 class="ui dividing header">Variations</h2>
 
   <div class="example">

--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -496,7 +496,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
   <h2 class="ui dividing header">States</h2>
 
   <div class="example">
-    <h4 class="ui header">Disabled</h4>
+    <h4 class="ui header">Disabled <span class="ui black label">New in 2.8.8</span></h4>
     <p>A card may show its content is disabled</p>
     <div class="ui disabled card">
         <div class="content">
@@ -517,7 +517,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
   <div class="example">
-    <h4 class="ui header">Loading</h4>
+    <h4 class="ui header">Loading <span class="ui black label">New in 2.8.8</span></h4>
     <p>A card may show its content is being loaded</p>
     <div class="ui loading card">
         <div class="content">


### PR DESCRIPTION
## Description
`disabled` and `loading` state examples as of https://github.com/fomantic/Fomantic-UI/pull/1762

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/103111192-936f4800-464a-11eb-99a1-410afad107b9.png)
![image](https://user-images.githubusercontent.com/18379884/103111195-9d914680-464a-11eb-9496-ca9498482c4b.png)
