### PR TITLE
feat(icon): colored bordered circular examples

### DIFF
--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -7091,7 +7091,13 @@ themes      : ['Default']
       <i class="circular inverted users icon"></i>
       <i class="circular inverted teal users icon"></i>
     </div>
-
+    <div class="example">
+      <h4 class="ui header">Circular Colored <span class="ui black label>New in 2.8.8</span></h4>
+      <p>The circular color can appear in the same color as the icon itself</p>
+      <i class="circular colored red users icon"></i>
+      <i class="circular colored green users icon"></i>
+      <i class="circular colored blue users icon"></i>
+    </div>
     <div class="example">
       <h4 class="ui header">Bordered</h4>
       <div class="ui ignored info message">
@@ -7103,7 +7109,13 @@ themes      : ['Default']
       <i class="bordered inverted black users icon"></i>
       <i class="bordered inverted teal users icon"></i>
     </div>
-
+    <div class="example">
+      <h4 class="ui header">Bordered Colored <span class="ui black label>New in 2.8.8</span></h4>
+      <p>The bordered color can appear in the same color as the icon itself</p>
+      <i class="circular colored red users icon"></i>
+      <i class="circular colored green users icon"></i>
+      <i class="circular colored blue users icon"></i>
+    </div>
     <div class="example">
       <h4 class="ui header">Colored</h4>
       <p>An icon can be formatted with different colors</p>

--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -7112,9 +7112,9 @@ themes      : ['Default']
     <div class="example">
       <h4 class="ui header">Bordered Colored <span class="ui black label">New in 2.8.8</span></h4>
       <p>The bordered color can appear in the same color as the icon itself</p>
-      <i class="circular colored red users icon"></i>
-      <i class="circular colored green users icon"></i>
-      <i class="circular colored blue users icon"></i>
+      <i class="bordered colored red users icon"></i>
+      <i class="bordered colored green users icon"></i>
+      <i class="bordered colored blue users icon"></i>
     </div>
     <div class="example">
       <h4 class="ui header">Colored</h4>

--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -7092,7 +7092,7 @@ themes      : ['Default']
       <i class="circular inverted teal users icon"></i>
     </div>
     <div class="example">
-      <h4 class="ui header">Circular Colored <span class="ui black label>New in 2.8.8</span></h4>
+      <h4 class="ui header">Circular Colored <span class="ui black label">New in 2.8.8</span></h4>
       <p>The circular color can appear in the same color as the icon itself</p>
       <i class="circular colored red users icon"></i>
       <i class="circular colored green users icon"></i>
@@ -7110,7 +7110,7 @@ themes      : ['Default']
       <i class="bordered inverted teal users icon"></i>
     </div>
     <div class="example">
-      <h4 class="ui header">Bordered Colored <span class="ui black label>New in 2.8.8</span></h4>
+      <h4 class="ui header">Bordered Colored <span class="ui black label">New in 2.8.8</span></h4>
       <p>The bordered color can appear in the same color as the icon itself</p>
       <i class="circular colored red users icon"></i>
       <i class="circular colored green users icon"></i>


### PR DESCRIPTION
## Description
Examples for new variations `circular colored` and `bordered colored` of the `icon` component as of https://github.com/fomantic/Fomantic-UI/pull/1856

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/106369083-d3fb6900-634e-11eb-95b8-b6c559b6e678.png)
![image](https://user-images.githubusercontent.com/18379884/106369133-2e94c500-634f-11eb-8f82-342254172a2d.png)
