### PR TITLE
chore(elements): fix typo

### DIFF
--- a/server/documents/elements/container.html.eco
+++ b/server/documents/elements/container.html.eco
@@ -157,7 +157,7 @@ themes      : ['Default']
 
     <div class="no example">
       <h4 class="ui header">Text Container</h4>
-      <p>A container can reduce its maximum width to more naturally accomodate a single column of text</p>
+      <p>A container can reduce its maximum width to more naturally accommodate a single column of text</p>
       <div class="ui info message">
         A text container is a simpler markup alternative to using a grid with a single column, and is designed to have a reasonable maximum width for displaying flowing text
       </div>

--- a/server/documents/elements/emoji.html.eco
+++ b/server/documents/elements/emoji.html.eco
@@ -37,7 +37,7 @@ themes      : ['Default']
     <div class="ui ignored warning message">
       Emojis serve a very similar function to text in a page. In Fomantic emojis receive a special tag <code>&lt;em&gt;</code> which allow for an abbreviated markup when sitting along-side text.
         <br>
-        Because of the complexity and possible interferance with existing fomantic classnames, emoji names have to be provided via the <code>data-emoji</code> attribute instead of usual classnaming.
+        Because of the complexity and possible interference with existing fomantic classnames, emoji names have to be provided via the <code>data-emoji</code> attribute instead of usual classnaming.
     </div>
     <div class="ui ignored message">
         By default all emoji images are linked to a CDN and are <b>not part of Fomantic itself</b>.

--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -121,8 +121,8 @@ themes      : ['Default']
         <div class="column"><i class="fish icon" data-search-terms="fauna, gold, seafood, swimming"></i>fish</div>
         <div class="column"><i class="frog icon" data-search-terms="amphibian, bullfrog, fauna, hop, kermit, kiss, prince, ribbit, toad, wart"></i>frog</div>
         <div class="column"><i class="hippo icon" data-search-terms="animal, fauna, hippopotamus, hungry, mammal"></i>hippo</div>
-        <div class="column"><i class="horse icon" data-search-terms="equus, fauna, mammmal, mare, neigh, pony"></i>horse</div>
-        <div class="column"><i class="horse head icon" data-search-terms="equus, fauna, mammmal, mare, neigh, pony"></i>horse head</div>
+        <div class="column"><i class="horse icon" data-search-terms="equus, fauna, mammal, mare, neigh, pony"></i>horse</div>
+        <div class="column"><i class="horse head icon" data-search-terms="equus, fauna, mammal, mare, neigh, pony"></i>horse head</div>
         <div class="column"><i class="kiwi bird icon" data-search-terms="bird, fauna, new zealand"></i>kiwi bird</div>
         <div class="column"><i class="otter icon" data-search-terms="animal, badger, fauna, fur, mammal, marten"></i>otter</div>
         <div class="column"><i class="paw icon" data-search-terms="animal, cat, dog, pet, print"></i>paw</div>
@@ -1572,8 +1572,8 @@ themes      : ['Default']
         <div class="column"><i class="eye icon" data-search-terms="look, optic, see, seen, show, sight, views, visible"></i>eye</div>
         <div class="column"><i class="eye dropper icon" data-search-terms="beaker, clone, color, copy, eyedropper, pipette"></i>eye dropper</div>
         <div class="column"><i class="eye outline icon" data-search-terms="look, optic, see, seen, show, sight, views, visible"></i>eye outline</div>
-        <div class="column"><i class="eye slash icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visiblity"></i>eye slash</div>
-        <div class="column"><i class="eye slash outline icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visiblity"></i>eye slash outline</div>
+        <div class="column"><i class="eye slash icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visibility"></i>eye slash</div>
+        <div class="column"><i class="eye slash outline icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visibility"></i>eye slash outline</div>
         <div class="column"><i class="fill icon" data-search-terms="bucket, color, paint, paint bucket"></i>fill</div>
         <div class="column"><i class="fill drip icon" data-search-terms="bucket, color, drop, paint, paint bucket, spill"></i>fill drip</div>
         <div class="column"><i class="highlighter icon" data-search-terms="edit, marker, sharpie, update, write"></i>highlighter</div>
@@ -1906,8 +1906,8 @@ themes      : ['Default']
         <div class="column"><i class="grin alternate outline icon" data-search-terms="emoticon, face, laugh, smile"></i>grin alternate outline</div>
         <div class="column"><i class="grin beam icon" data-search-terms="emoticon, face, laugh, smile"></i>grin beam</div>
         <div class="column"><i class="grin beam outline icon" data-search-terms="emoticon, face, laugh, smile"></i>grin beam outline</div>
-        <div class="column"><i class="grin beam sweat icon" data-search-terms="embarass, emoticon, face, smile"></i>grin beam sweat</div>
-        <div class="column"><i class="grin beam sweat outline icon" data-search-terms="embarass, emoticon, face, smile"></i>grin beam sweat outline</div>
+        <div class="column"><i class="grin beam sweat icon" data-search-terms="embarrass, emoticon, face, smile"></i>grin beam sweat</div>
+        <div class="column"><i class="grin beam sweat outline icon" data-search-terms="embarrass, emoticon, face, smile"></i>grin beam sweat outline</div>
         <div class="column"><i class="grin hearts icon" data-search-terms="emoticon, face, love, smile"></i>grin hearts</div>
         <div class="column"><i class="grin hearts outline icon" data-search-terms="emoticon, face, love, smile"></i>grin hearts outline</div>
         <div class="column"><i class="grin outline icon" data-search-terms="emoticon, face, laugh, smile"></i>grin outline</div>
@@ -2193,7 +2193,7 @@ themes      : ['Default']
         <div class="column"><i class="balance scale left icon" data-search-terms="justice, legal, measure, unbalanced, weight"></i>balance scale left</div>
         <div class="column"><i class="balance scale right icon" data-search-terms="justice, legal, measure, unbalanced, weight"></i>balance scale right</div>
         <div class="column"><i class="book icon" data-search-terms="diary, documentation, journal, library, read"></i>book</div>
-        <div class="column"><i class="cash register icon" data-search-terms="buy, cha-ching, change, checkout, commerce, leaerboard, machine, pay, payment, purchase, store"></i>cash register</div>
+        <div class="column"><i class="cash register icon" data-search-terms="buy, cha-ching, change, checkout, commerce, leaderboard, machine, pay, payment, purchase, store"></i>cash register</div>
         <div class="column"><i class="chart line icon" data-search-terms="activity, analytics, chart, dashboard, gain, graph, increase, line"></i>chart line</div>
         <div class="column"><i class="chart pie icon" data-search-terms="analytics, chart, diagram, graph, pie"></i>chart pie</div>
         <div class="column"><i class="coins icon" data-search-terms="currency, dime, financial, gold, money, penny"></i>coins</div>
@@ -2814,8 +2814,8 @@ themes      : ['Default']
         <div class="column"><i class="eye icon" data-search-terms="look, optic, see, seen, show, sight, views, visible"></i>eye</div>
         <div class="column"><i class="eye dropper icon" data-search-terms="beaker, clone, color, copy, eyedropper, pipette"></i>eye dropper</div>
         <div class="column"><i class="eye outline icon" data-search-terms="look, optic, see, seen, show, sight, views, visible"></i>eye outline</div>
-        <div class="column"><i class="eye slash icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visiblity"></i>eye slash</div>
-        <div class="column"><i class="eye slash outline icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visiblity"></i>eye slash outline</div>
+        <div class="column"><i class="eye slash icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visibility"></i>eye slash</div>
+        <div class="column"><i class="eye slash outline icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visibility"></i>eye slash outline</div>
         <div class="column"><i class="file image icon" data-search-terms="document, image, jpg, photo, png"></i>file image</div>
         <div class="column"><i class="file image outline icon" data-search-terms="document, image, jpg, photo, png"></i>file image outline</div>
         <div class="column"><i class="film icon" data-search-terms="cinema, movie, strip, video"></i>film</div>
@@ -2937,8 +2937,8 @@ themes      : ['Default']
         <div class="column"><i class="external link square alternate icon" data-search-terms="external-link-square, new, open, share"></i>external link square alternate</div>
         <div class="column"><i class="eye icon" data-search-terms="look, optic, see, seen, show, sight, views, visible"></i>eye</div>
         <div class="column"><i class="eye outline icon" data-search-terms="look, optic, see, seen, show, sight, views, visible"></i>eye outline</div>
-        <div class="column"><i class="eye slash icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visiblity"></i>eye slash</div>
-        <div class="column"><i class="eye slash outline icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visiblity"></i>eye slash outline</div>
+        <div class="column"><i class="eye slash icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visibility"></i>eye slash</div>
+        <div class="column"><i class="eye slash outline icon" data-search-terms="blind, hide, show, toggle, unseen, views, visible, visibility"></i>eye slash outline</div>
         <div class="column"><i class="file icon" data-search-terms="document, new, page, pdf, resume"></i>file</div>
         <div class="column"><i class="file alternate icon" data-search-terms="document, file-text, invoice, new, page, pdf"></i>file alternate</div>
         <div class="column"><i class="file alternate outline icon" data-search-terms="document, file-text, invoice, new, page, pdf"></i>file alternate outline</div>

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -507,12 +507,10 @@ themes      : ['Default', 'GitHub']
   <div class="another example" data-use-content="true">
     <div class="ignored ui warning message">
       For backward-compatibility during v2.x, <code>close</code>/<code>delete</code> icon.
-      
       <ul>
         <li>Requires <code>left icon</code> to be added to the parent <code>label</code> when the icon is placed on the left of a label.</li>
         <li>Does not require <code>right icon</code> to be added to parent <code>label</code> when the icon is placed on the right of the label.</li>
       </ul>
-      
       This rule may be simplified in a later minor or major version.
     </div>
 
@@ -534,7 +532,7 @@ themes      : ['Default', 'GitHub']
       <i class="delete icon"></i>
     </div>
   </div>
-    
+
   <div class="example" data-use-content="true" data-class="image" data-tag="img">
     <h4 class="ui header">Image</h4>
     <p>A label can include an image</p>

--- a/server/documents/elements/rail.html.eco
+++ b/server/documents/elements/rail.html.eco
@@ -25,7 +25,7 @@ type        : 'UI Element'
     <h3 class="ui header">Adjusting Sizes</h3>
     <p>Railed content will most likely require arbitrary breakpoints that are specific to your site's content, to ensure they do not exceed the horizontal width of a user's browser.</p>
     <p>Rails are generally used beside long, single-column containers with long-form content like blog posts, articles, or user profiles. Generally your main text container width should be set between around <code>600-800px</code> depending on your font size to <a href="http://baymard.com/blog/line-length-readability" target="_blank">optimize line length for readability</a>.</p>
-    <p>This set-up means most tablet browsers can only accomodate a single rail. Ultrabooks and lower resolution computers two small rails, and larger monitors, usually two full-sized rails. The specifics of this implementation is left up to you in your project.</p>
+    <p>This set-up means most tablet browsers can only accommodate a single rail. Ultrabooks and lower resolution computers two small rails, and larger monitors, usually two full-sized rails. The specifics of this implementation is left up to you in your project.</p>
     <div class="ui ignored warning message">
       The following examples do not use any breakpoints, so some railed content may appear outside your browser's viewport on smaller screens.
     </div>

--- a/server/documents/elements/reveal.html.eco
+++ b/server/documents/elements/reveal.html.eco
@@ -127,7 +127,7 @@ themes      : ['Default']
     <h4 class="ui header">Active</h4>
     <p>An active reveal displays its hidden content</p>
     <div class="ui ignored info message">
-      Adding the class <code>active</code> can allow you to show the hidden contents programatically
+      Adding the class <code>active</code> can allow you to show the hidden contents programmatically
     </div>
     <div class="ui active move left reveal">
       <div class="visible content">
@@ -141,7 +141,6 @@ themes      : ['Default']
 
   <h2 class="ui dividing header">Variations</h2>
 
-
   <div class="example">
     <h4 class="ui header">Instant</h4>
     <p>An element can show its content without delay</p>
@@ -154,7 +153,6 @@ themes      : ['Default']
       </div>
     </div>
   </div>
-
 
   <h2 class="ui dividing header">States</h2>
 
@@ -170,7 +168,5 @@ themes      : ['Default']
       </div>
     </div>
   </div>
-
-
 
 </div>

--- a/server/documents/elements/step.html.eco
+++ b/server/documents/elements/step.html.eco
@@ -620,7 +620,7 @@ themes      : ['Default', 'Basic', 'GitHub']
         </div>
       </div>
     </div>
-    
+
   </div>
 
   <div class="another example">
@@ -646,7 +646,7 @@ themes      : ['Default', 'Basic', 'GitHub']
         </div>
       </div>
     </div>
-    
+
   </div>
 
   <div class="another example">
@@ -675,7 +675,7 @@ themes      : ['Default', 'Basic', 'GitHub']
         </div>
       </div>
     </div>
-    
+
   </div>
 
 


### PR DESCRIPTION
fix typo in the following pages

- `elements/container`
- `elements/emoji`
- `elements/icon`
- `elements/label`
- `elements/rail`
- `elements/reveal`
- `elements/step`