### PR TITLE
chore(modules): fix typo

### DIFF
--- a/server/documents/modules/checkbox.html.eco
+++ b/server/documents/modules/checkbox.html.eco
@@ -486,7 +486,7 @@ themes      : ['Default', 'Colored']
                   allChecked = false;
                 }
               });
-              // set parent checkbox state, but dont trigger its onChange callback
+              // set parent checkbox state, but don't trigger its onChange callback
               if(allChecked) {
                 $parentCheckbox.checkbox('set checked');
               }
@@ -505,7 +505,7 @@ themes      : ['Default', 'Colored']
 
     <div class="cancel example">
       <h4 class="ui header">Checking Conditions</h4>
-      <p><a href="/modules/checkbox.html">Checkboxes</a> include four new callbacks <code>beforeChecked</code>, <code>beforeUnchecked</code>, <code>beforeDeterminate</code>, and <code>beforeIndeterminate</code>, returning <code>false</code> from these callbacks will cancel the action from occuring before the input value is updated.</p>
+      <p><a href="/modules/checkbox.html">Checkboxes</a> include four new callbacks <code>beforeChecked</code>, <code>beforeUnchecked</code>, <code>beforeDeterminate</code>, and <code>beforeIndeterminate</code>, returning <code>false</code> from these callbacks will cancel the action from occurring before the input value is updated.</p>
       <div class="ui checkbox">
         <input type="checkbox" name="example" />
         <label>Maybe this will work</label>
@@ -810,7 +810,7 @@ themes      : ['Default', 'Colored']
         <tr>
           <td>onIndeterminate</td>
           <td>HTML input element</td>
-          <td>Callback after a checkbox is set to undeterminate.</td>
+          <td>Callback after a checkbox is set to indeterminate.</td>
         </tr>
         <tr>
           <td>onDeterminate</td>
@@ -830,7 +830,7 @@ themes      : ['Default', 'Colored']
         <tr>
           <td>beforeIndeterminate</td>
           <td>HTML input element</td>
-          <td>Callback before a checkbox is set to undeterminate. Can cancel change by returning <code>false</code></td>
+          <td>Callback before a checkbox is set to indeterminate. Can cancel change by returning <code>false</code></td>
         </tr>
         <tr>
           <td>beforeDeterminate</td>

--- a/server/documents/modules/embed.html.eco
+++ b/server/documents/modules/embed.html.eco
@@ -22,12 +22,12 @@ type        : 'UI Module'
 
     <div class="no example">
       <h4 class="ui header">Responsive Aspect Ratio</h4>
-      <p>Embeds use an <a href="http://alistapart.com/article/creating-intrinsic-ratios-for-video">instrinsic aspect ratio</a> which allows them to resize responsively based on their expected aspect ratio and not by using a single specified width or height.</p>
+      <p>Embeds use an <a href="http://alistapart.com/article/creating-intrinsic-ratios-for-video">intrinsic aspect ratio</a> which allows them to resize responsively based on their expected aspect ratio and not by using a single specified width or height.</p>
     </div>
     <div class="no example">
       <h4 class="ui header">Only Load After Interaction</h4>
       <p>Including an <code>iframe</code> embed directly will automatically load all iframe contents on page load which can drastically reduce the responsiveness of a page.</p>
-      <p>Semantic's embed combats this by not  loading iframe content until a user has interacted with your embed's placeholder content.</p>
+      <p>Semantic's embed combats this by not loading iframe content until a user has interacted with your embed's placeholder content.</p>
       <p>To give you an idea of how much file size including an embed will add to your page load see the chart below</p>
       <div class="ui ignored info message">The following are download estimates taken from firebug and a single sample embed. Individual results may vary.</div>
       <table class="ui celled two column table">

--- a/server/documents/modules/nag.html.eco
+++ b/server/documents/modules/nag.html.eco
@@ -171,7 +171,7 @@ type        : 'UI Module'
         </div>
         <p></p>
         <div class="ui massive nag">
-          <div class="title">Masssive nag</div>
+          <div class="title">Massive nag</div>
           <i class="close icon"></i>
         </div>
 

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -401,7 +401,7 @@ type        : 'UI Module'
     </div>
 
     <h4 class="ui header">Local Object</h4>
-    <p>Local search results allow you to search across specified properties of a javacript object literal looking for matching values</p>
+    <p>Local search results allow you to search across specified properties of a javascript object literal looking for matching values</p>
     <p>
       You can set which fields are searchable using the <code>searchFields</code> setting. Local object search can only display standard search results (not categories).
     </p>
@@ -432,7 +432,7 @@ type        : 'UI Module'
 
     <h2 class="ui dividing header">Server Responses</h2>
 
-    <div class="ui info message">You may also consider adding a top level property like <code>success: true</code> and using API's <code>successTest</code> parameter to determine whether a server response is actually succesful, even if it returns the correct HTTP code</div>
+    <div class="ui info message">You may also consider adding a top level property like <code>success: true</code> and using API's <code>successTest</code> parameter to determine whether a server response is actually successful, even if it returns the correct HTTP code</div>
 
     <h4 class="ui header">Standard</h4>
     <div class="code" data-title="Server JSON Response">
@@ -504,7 +504,7 @@ type        : 'UI Module'
     </div>
 
 
-    <h2 class="ui dividing header">Retreiving Results</h2>
+    <h2 class="ui dividing header">Retrieving Results</h2>
 
     <h4 class="ui header">Unique IDs</h4>
     <p>If no <code>id</code> property is included on a result, a key will automatically be generated when your results are returned for each result.</p>
@@ -678,7 +678,7 @@ type        : 'UI Module'
       	</div>
       </div>
       <p><a href="/behaviors/api.html">API</a> provides a callback <a href="/behaviors/api.html#response-callbacks"><code>onResponse</code></a> that can be used to restructure third party APIs to match the expected server response for search.</p>
-      <p>You can also use <a href="/behaviors/api.html#mocking-responses"><code>mockResponseAsync</code></a> to use a custom backend for fullfilling searches.</p>
+      <p>You can also use <a href="/behaviors/api.html#mocking-responses"><code>mockResponseAsync</code></a> to use a custom backend for fulfilling searches.</p>
       <div class="ui search">
         <div class="ui left icon input">
           <input class="prompt" type="text" placeholder="Search GitHub">

--- a/server/documents/modules/shape.html.eco
+++ b/server/documents/modules/shape.html.eco
@@ -340,7 +340,7 @@ themes      : ['default']
         </tr>
         <tr>
           <td>queue(animation)</td>
-          <td>Queues an animationtill after current animation</td>
+          <td>Queues an animation after current animation</td>
         </tr>
         <tr>
           <td>repaint</td>
@@ -409,7 +409,7 @@ themes      : ['default']
             <div class="ui bulleted list">
               <div class="item">When set to <code>next</code> will use the width of the next <code>side</code> during the shape's animation.</div>
               <div class="item">When set to <code>initial</code> it will use the width of the shape at initialization.</div>
-              <div class="item">When set to a specifix pixel height, will force the width to that height.</div>
+              <div class="item">When set to a specific pixel height, will force the width to that height.</div>
             </div>
           </td>
         </tr>
@@ -420,7 +420,7 @@ themes      : ['default']
             <div class="ui bulleted list">
               <div class="item">When set to <code>next</code> will use the height of the next <code>side</code> during the shape's animation.</div>
               <div class="item">When set to <code>initial</code> it will use the height of the shape at initialization.</div>
-              <div class="item">When set to a specifix pixel height, will force the height to that height.</div>
+              <div class="item">When set to a specific pixel height, will force the height to that height.</div>
             </div>
           </td>
         </tr>

--- a/server/documents/modules/tab.html.eco
+++ b/server/documents/modules/tab.html.eco
@@ -318,7 +318,7 @@ themes      : ['Default']
 
 
     <div class="dynamic no example">
-      <h4 class="header">Retreiving Remote Content</h4>
+      <h4 class="header">Retrieving Remote Content</h4>
       <p>Using <code>auto: true</code> will load the tab's path from your server with additional headers to specify an in-page request. When <a href="#settings"><code>cache: true</code></a> is set, re-opening a tab will be loaded from cache without a server request.</p>
       <div class="ui ignored warning message">
         API requests for the following example have been faked using <a href="/behaviors/api.html#using-custom-backends">mockResponse</a> API setting to avoid network overhead.

--- a/server/documents/modules/toast.html.eco
+++ b/server/documents/modules/toast.html.eco
@@ -91,7 +91,7 @@ themes      : ['Default']
         $('body')
           .toast({
             class: 'error',
-            message: `An error occured !`
+            message: `An error occurred !`
           })
         ;
         </div>
@@ -127,7 +127,7 @@ themes      : ['Default']
     </div>
     <div class="no example">
           <h4 class="ui header">Attached Position<span class="ui black label">New in 2.8.8</span></h4>
-          <p>A toast can have an attached position which will show the toast over the whole width of the screen. Just like notificatons on mobile devices.</p>
+          <p>A toast can have an attached position which will show the toast over the whole width of the screen. Just like notifications on mobile devices.</p>
           <div class="ui warning message">
             Attached positions with centered content only support attached actions. See the  <a href="#actions-and-centered-and-attached-position">examples tab</a> for more info.
           </div>
@@ -191,7 +191,7 @@ themes      : ['Default']
           })
         ;
         </div>
-        <p>You can even avoid a toast to disapear.</p>
+        <p>You can even avoid a toast to disappear.</p>
         <div class="code" data-demo="true">
         $('body')
           .toast({

--- a/server/documents/modules/transition.html.eco
+++ b/server/documents/modules/transition.html.eco
@@ -691,7 +691,7 @@ type        : 'UI Module'
         <tr>
           <td>skipInlineHidden</td>
           <td>false</td>
-          <td>Whether initially inline hidden objects should be skipped for transition. Useful, if you do the transition for child objects also, but want to have inline hidden childs (defined by <code>style="display:none;"</code>) still kept hidden while the parent gets animated. <a href="/modules/accordion.html">Accordion</a> uses this.</td>
+          <td>Whether initially inline hidden objects should be skipped for transition. Useful, if you do the transition for child objects also, but want to have inline hidden children (defined by <code>style="display:none;"</code>) still kept hidden while the parent gets animated. <a href="/modules/accordion.html">Accordion</a> uses this.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
fix typo in the following pages

- `modules/checkbox`
- `modules/embed`
- `modules/nag`
- `modules/search`
- `modules/shape`
- `modules/tab`
- `modules/toast`
- `modules/transition`