### PR TITLE
fix(search): cancel query behavior exists twice

### DIFF
--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -571,10 +571,6 @@ type        : 'UI Module'
           <td>Search object for specified query and return results</td>
         </tr>
         <tr>
-          <td>cancel query</td>
-          <td>Cancels current remote search request</td>
-        </tr>
-        <tr>
           <td>is focused</td>
           <td>Whether search is currently focused</td>
         </tr>


### PR DESCRIPTION
## Description
The `cancel request` behavior was documented twice.

## Closes
#273 