### PR TITLE
fix(menu): added disabled example

### DIFF
--- a/server/documents/collections/menu.html.eco
+++ b/server/documents/collections/menu.html.eco
@@ -727,6 +727,15 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
     </div>
   </div>
 
+  <div class="example">
+    <h4 class="ui header">Disabled</h4>
+    <p>A menu item can be disabled</p>
+    <div class="ui compact menu">
+      <div class="disabled item">
+        Link
+      </div>
+    </div>
+  </div>
 
   <h2 class="ui dividing header">Variations</h2>
 


### PR DESCRIPTION
## Description

Added an example for `disabled item`

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/116468719-815c1b00-a871-11eb-81ea-87e8c000cfff.png)
