### PR TITLE
feat(dimmer,dropdown,modal,popup): individual show/hide transition

### DIFF
--- a/server/documents/modules/dimmer.html.eco
+++ b/server/documents/modules/dimmer.html.eco
@@ -589,6 +589,25 @@ themes      : ['Default']
           <td>Whether to dim dimmers using CSS transitions.</td>
         </tr>
         <tr>
+          <td>transition</td>
+          <td>
+            fade
+          </td>
+          <td>Named transition to use when animating menu in and out. Fade and slide down are available without including <a href="/modules/transition.html">ui transitions</a>
+          <br>
+              <p>Alternatively you can provide an object to set individual values for hide/show transitions as well as hide/show duration <span class="ui black tiny label">New in 2.8.8</span>
+                  <div class="code">
+                  {
+                      showMethod   : 'fade',
+                      showDuration : 200,
+                      hideMethod   : 'zoom',
+                      hideDuration : 500,
+                  }
+                  </div>
+              </p>
+          </td>
+        </tr>
+        <tr>
           <td>duration</td>
           <td>
             <div class="code">
@@ -598,21 +617,7 @@ themes      : ['Default']
             }
             </div>
           </td>
-          <td>Animation duration of dimming. If an integer is used, that value will apply to both show and hide animations.</td>
-        </tr>
-        <tr>
-          <td>transition</td>
-          <td>
-            fade
-          </td>
-          <td>Named transition to use when animating menu in and out. Fade and slide down are available without including <a href="/modules/transition.html">ui transitions</a><br><br><div class="ui black tiny label">New in 2.8.8</div><br>Instead of a string, you can also provide an object to use individual transition methods for show and hide
-              <div class="code">
-                  {
-                    showMethod: 'fade',
-                    hideMethod: 'zoom'
-                  }
-            </div>
-          </td>
+          <td>Animation duration of dimming. If an integer is used, that value will apply to both show and hide animations. Will be ignored completely when individual hide/show duration values are provided via the <code>transition</code> setting</td>
         </tr>
         <tr>
             <td>displayLoader</td>

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -3588,19 +3588,30 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>
             auto (slide down / slide up)
           </td>
-          <td>Named transition to use when animating menu in and out. Defaults to <code>slide down</code> or <code>slide up</code> depending on dropdown direction. Fade and slide down are available without including <a href="/modules/transition.html">ui transitions</a></td>
-        </tr>
-        <tr>
-          <td>displayType</td>
-          <td>false</td>
-          <td>Specify the final transition display type (block, inline-block etc) so that it doesn't have to be calculated.</td>
+          <td>Named transition to use when animating menu in and out. Defaults to <code>slide down</code> or <code>slide up</code> depending on dropdown direction. Fade and slide down are available without including <a href="/modules/transition.html">ui transitions</a>
+                <p>Alternatively you can provide an object to set individual values for hide/show transitions as well as hide/show duration <span class="ui black tiny label">New in 2.8.8</span>
+                    <div class="code">
+                    {
+                        showMethod   : 'fade',
+                        showDuration : 200,
+                        hideMethod   : 'zoom',
+                        hideDuration : 500,
+                    }
+                    </div>
+              </p>
+          </td>
         </tr>
         <tr>
           <td>duration</td>
           <td>
             200
           </td>
-          <td>Duration of animation events</td>
+          <td>Duration of animation events. The value will be ignored when individual hide/show duration values are provided via the <code>transition</code> setting</td>
+        </tr>
+        <tr>
+          <td>displayType</td>
+          <td>false</td>
+          <td>Specify the final transition display type (block, inline-block etc) so that it doesn't have to be calculated.</td>
         </tr>
         <tr>
           <td>keys</td>

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -1069,14 +1069,25 @@ themes      : ['Default', 'Material']
           <td>
             scale
           </td>
-          <td>Named transition to use when animating menu in and out, full list can be found in <a href="/modules/transition.html">ui transitions</a> docs.</td>
+          <td>Named transition to use when animating menu in and out, full list can be found in <a href="/modules/transition.html">ui transitions</a> docs.<br>
+            <p>Alternatively you can provide an object to set individual values for hide/show transitions as well as hide/show duration <span class="ui black tiny label">New in 2.8.8</span>
+                <div class="code">
+                {
+                    showMethod   : 'fade',
+                    showDuration : 200,
+                    hideMethod   : 'zoom,
+                    hideDuration : 500,
+                }
+                </div>
+            </p>
+          </td>
         </tr>
         <tr>
           <td>duration</td>
           <td>
             400
           </td>
-          <td>Duration of animation</td>
+          <td>Duration of animation. The value will be ignored when individual hide/show duration values are provided via the <code>transition</code> setting</td>
         </tr>
         <tr>
           <td>queue</td>

--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -825,14 +825,25 @@ themes      : ['Default']
           <td>
             scale
           </td>
-          <td>Named transition to use when animating menu in and out.</td>
+          <td>Named transition to use when animating menu in and out.<br>
+            <p>Alternatively you can provide an object to set individual values for hide/show transitions as well as hide/show duration <span class="ui black tiny label">New in 2.8.8</span>
+                <div class="code">
+                {
+                    showMethod   : 'fade',
+                    showDuration : 200,
+                    hideMethod   : 'zoom',
+                    hideDuration : 500,
+                }
+                </div>
+            </p>
+          </td>
         </tr>
         <tr>
           <td>duration</td>
           <td>
             200
           </td>
-          <td>Duration of animation events</td>
+          <td>Duration of animation events. The value will be ignored when individual hide/show duration values are provided via the <code>transition</code> setting</td>
         </tr>
         <tr>
           <td>arrowPixelsFromEdge <div class="ui teal label">New in 2.3</div></td>


### PR DESCRIPTION
## Description
Added settings info for the new unique transition syntax for individual show/hide methods/duration in dimmer, modal, popup and dropdown as of
https://github.com/fomantic/Fomantic-UI/pull/1867
https://github.com/fomantic/Fomantic-UI/pull/1869
https://github.com/fomantic/Fomantic-UI/pull/1966
https://github.com/fomantic/Fomantic-UI/pull/1974

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/120112305-916b6100-c175-11eb-8113-8a2ee5c84c2c.png)
