### PR TITLE
fix(chore): slashes in anchorpoints let into console error

### DIFF
--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -1450,7 +1450,7 @@ semantic.ready = function() {
     window.Transifex.live.onTranslatePage(handler.showLanguageModal);
   }
 
-  if(window.location.hash) {
+  if(window.location.hash && window.location.hash.indexOf('/')===-1) {
     var
       $element = $(window.location.hash),
       position = $element.offset().top + 10

--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -1453,7 +1453,7 @@ semantic.ready = function() {
   if(window.location.hash && window.location.hash.indexOf('/')===-1) {
     var
       $element = $(window.location.hash),
-      position = $element.offset().top + 10
+      position = $element.offset() ? $element.offset().top + 10 : 0
     ;
     $element
       .addClass('active')


### PR DESCRIPTION
## Description

Whenever a link to the docs contains a anchorpoint starting with a "#/" in the URL (used by the tab history plugin) this let into a console error, because jquery is not able to retrieve a matching element (runs into a console error itself)

Additionally when a non existing anchor was given the whole docs script broke

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/123097010-fc841c80-d42f-11eb-87ec-329bd01e530f.png)
![slashhasherror](https://user-images.githubusercontent.com/18379884/123097066-09a10b80-d430-11eb-9c57-cfd75ca019b9.gif)

## Closes
#135 
