### PR TITLE
fix(calendar): 2 digits date notation for safari support

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -476,7 +476,7 @@ themes      : ['Default']
       <div class="code" data-type="javascript">
       $('#disableddates_calendar')
         .calendar({
-            initialDate: new Date('2018-12-1'),
+            initialDate: new Date('2018-12-01'),
             disabledDates: [{
                     date: new Date('2018-12-22'),
                     message: 'xmas gift shopping'
@@ -507,7 +507,7 @@ themes      : ['Default']
           $('#disabledmonth_calendar')
           .calendar({
             type: 'date',
-            initialDate: new Date('2020-12-1'),
+            initialDate: new Date('2020-12-01'),
             disabledDates: [{
                 month: 11,     //Javascript months start from 0 (!)
                 message: 'All days in December are booked out'
@@ -534,7 +534,7 @@ themes      : ['Default']
           $('#disabledyear_calendar')
           .calendar({
             type: 'date',
-            initialDate: new Date('2020-12-1'),
+            initialDate: new Date('2020-12-01'),
             disabledDates: [{
                 year: 2020,
                 message: '2020 is not available'
@@ -562,11 +562,11 @@ themes      : ['Default']
           $('#enableddates_calendar')
           .calendar({
             type: 'date',
-            initialDate: new Date('2019-3-1'),
+            initialDate: new Date('2019-03-01'),
             enabledDates: [
-                new Date('2018-3-5'),
-                new Date('2018-3-10'),
-                new Date('2018-3-20')
+                new Date('2018-03-05'),
+                new Date('2018-03-10'),
+                new Date('2018-03-20')
             ]
           })
           ;
@@ -585,14 +585,14 @@ themes      : ['Default']
       </div>
       <div class="evaluated code" data-type="javascript">
       $('#eventdates_calendar').calendar({
-          initialDate: new Date('2019-4-1'),
+          initialDate: new Date('2019-04-01'),
           eventDates: [
               {
-                date: new Date('2019-4-21'),
+                date: new Date('2019-04-21'),
                 message: 'Show me in light purple',
                 class: 'inverted purple'
               },{
-                date: new Date('2019-4-22'),
+                date: new Date('2019-04-22'),
                 message: 'Show me in green',
                 class: 'green'
               }
@@ -609,15 +609,15 @@ themes      : ['Default']
       </div>
       <div class="evaluated code" data-type="javascript">
       $('#eventdates2_calendar').calendar({
-          initialDate: new Date('2019-4-1'),
+          initialDate: new Date('2019-04-01'),
           eventClass: 'inverted red',
           eventDates: [
-              new Date('2019-4-20'), //no message tooltip
+              new Date('2019-04-20'), //no message tooltip
               {
-                date: new Date('2019-4-21'),
+                date: new Date('2019-04-21'),
                 message: 'I got the default color (light red)'
               },{
-                date: new Date('2019-4-22'),
+                date: new Date('2019-04-22'),
                 message: 'Me too'
               }
           ]


### PR DESCRIPTION
## Description

Safaris Date() implementation does not support short 1 digit notations of month and day when converting from a string. Thus all related examples using this format are broken in Safari.

## Testcase
Try this on Safari 

### Broken
https://jsfiddle.net/lubber/9kp6dc1r/1/

### Fixed
https://jsfiddle.net/lubber/9kp6dc1r/2/

## Screenshots
### Broken
![image](https://user-images.githubusercontent.com/18379884/123545004-42a1ee80-d756-11eb-9af7-46783a6188b8.png)

### Fixed
![image](https://user-images.githubusercontent.com/18379884/123544996-3e75d100-d756-11eb-9358-72a4ab886726.png)

## Closes
#290 