### PR TITLE
fix(validation): mix short and longhand notation possible since 2.8.8

### DIFF
--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -28,7 +28,7 @@ type        : 'UI Behavior'
       <h4 class="ui header">Specifying Validation Rules</h4>
       <p>Form validation requires passing in a validation object with the rules required to validate your form.</p>
       <div class="ui ignored info message">
-        A validation object includes a list of form elements, and rules to validate each field against. Fields are matched by either the <code>id</code>, <code>name</code>, or <code>data-validate</code> property (in that order) matching the identifier specified in the settings object. Validation objects must use either shorthand or longhand exclusively.
+        A validation object includes a list of form elements, and rules to validate each field against. Fields are matched by either the <code>id</code>, <code>name</code>, or <code>data-validate</code> property (in that order) matching the identifier specified in the settings object. As of 2.8.8, validation objects can mixed in shorthand or longhand notation.
       </div>
       <div class="ignore code" data-title="Shorthand Validation">
       $('.ui.form')

--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -28,7 +28,7 @@ type        : 'UI Behavior'
       <h4 class="ui header">Specifying Validation Rules</h4>
       <p>Form validation requires passing in a validation object with the rules required to validate your form.</p>
       <div class="ui ignored info message">
-        A validation object includes a list of form elements, and rules to validate each field against. Fields are matched by either the <code>id</code>, <code>name</code>, or <code>data-validate</code> property (in that order) matching the identifier specified in the settings object. As of 2.8.8, validation objects can mixed in shorthand or longhand notation.
+        A validation object includes a list of form elements, and rules to validate each field against. Fields are matched by either the <code>id</code>, <code>name</code>, or <code>data-validate</code> property (in that order) matching the identifier specified in the settings object. As of 2.8.8, validation objects can mix shorthand or longhand notation.
       </div>
       <div class="ignore code" data-title="Shorthand Validation">
       $('.ui.form')


### PR DESCRIPTION
## Description

Since 2.8.8, it is possible to mix short and longhand notation in validation rule objects as of https://github.com/fomantic/Fomantic-UI/pull/1810 .
This was missed to be added to the docs, so here it is.

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/124497136-b8433580-ddba-11eb-944b-4abbe7ea49d2.png)
