### PR TITLE
feat(calendar): new default value for constantheight

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -747,7 +747,7 @@ themes      : ['Default']
         </tr>
         <tr>
           <td>constantHeight</td>
-          <td>true</td>
+          <td>false</td>
           <td>Add row(s) to shorter months to keep day calendar height consistent (6 rows)</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Description
Changed default value for calendar `constantheight` setting as of https://github.com/fomantic/Fomantic-UI/pull/2043
