### PR TITLE
feat(flag): update version reference

### DIFF
--- a/server/documents/elements/flag.html.eco
+++ b/server/documents/elements/flag.html.eco
@@ -33,7 +33,7 @@ type        : 'UI Element'
 
     <h2 class="ui header">Types</h2>
     <div class="ui info message">
-      <p>Since Fomantic 2.8, flags are based on SVG emojis in the default theme. If you want to return to the sprite approach using the <a target="_blank" href="http://www.famfamfam.com/lab/icons/flags/">famfamfam icon set</a> (as used in Fomantic up to 2.7.8), you only have to change the <code>@flag</code> variable in your <code>theme.config</code> to <code>'famfamfam'</code>. However, the famfamfam theme does not support sizing and lots of flags are missing.</p>
+      <p>Since Fomantic 2.9.0, flags are based on SVG emojis in the default theme. If you want to return to the sprite approach using the <a target="_blank" href="http://www.famfamfam.com/lab/icons/flags/">famfamfam icon set</a> (as used in Fomantic up to 2.8.8), you only have to change the <code>@flag</code> variable in your <code>theme.config</code> to <code>'famfamfam'</code>. However, the famfamfam theme does not support sizing and lots of flags are missing.</p>
     </div>
     <table class="ui selectable sortable compact celled striped definition table">
       <thead>


### PR DESCRIPTION
## Description

The original PR for the new svg flags was supposed to be released by 2.8.0 back in 2019.
As this now changed to a new minor version in 2021 :wink:, this PR adjusts the Version reference to avoid confusion.