### PR TITLE
fix(emoji): fix anchor link generation

### DIFF
--- a/server/documents/elements/emoji.html.eco
+++ b/server/documents/elements/emoji.html.eco
@@ -15,9 +15,6 @@ themes      : ['Default']
 
 <%- @partial('header', { tabs: { emoji: 'Emojis', definition: 'Definition' } }) %>
 
-<script src="/javascript/emoji_strategy.js"></script>
-<script src="/javascript/emoji.js"></script>
-
 <div class="main ui container">
 
   <div class="ui active tab" data-tab="emoji">
@@ -125,3 +122,6 @@ themes      : ['Default']
   </div>
 
 </div>
+
+<script src="/javascript/emoji_strategy.js"></script>
+<script src="/javascript/emoji.js"></script>

--- a/server/files/javascript/emoji.js
+++ b/server/files/javascript/emoji.js
@@ -131,7 +131,4 @@ semantic.emoji.ready = function() {
   ;
 };
 
-// attach ready event
-$(document)
-  .ready(semantic.emoji.ready)
-;
+semantic.emoji.ready();


### PR DESCRIPTION
## Description
The section links on the right side are not working for emoji categories.

The emoji list is generated by javascript. However, this was done after the document was loaded and AFTER the central docs.js was auto generating the achor links. This PR changes the order of the execution, so by the time the anchor link routine seeks for proper segments, those are available at runtime now.

## Screenshots
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/18379884/128833083-1b442250-f7a6-4689-af3f-0413e9d05a03.png)|![image](https://user-images.githubusercontent.com/18379884/128832889-532edac9-c2e9-44c7-ad16-19cce760a580.png)|

