### PR TITLE
fix(modal): hint for autoclosing on actions

### DIFF
--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -1424,7 +1424,8 @@ themes      : ['Default', 'Material']
         <tr>
           <td>actions</td>
           <td>false</td>
-          <td>An array of objects. Each object defines an action with properties <code>text</code>,<code>class</code>,<code>icon</code> and <code>click</code>
+          <td>An array of objects. Each object defines an action with properties <code>text</code>,<code>class</code>,<code>icon</code> and <code>click</code>.
+            <div class="ui info message">Actions will close the modal by default. Return false from the click handler to prevent that.</div>
             <div class="code">
             actions: [{
                 text    : 'Wait',


### PR DESCRIPTION
## Description
This PR makes clear that each action buttons created out of a config setting will close the modal by default and the developer has to return false to prevent that

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/129004547-495b7283-0c32-4e3c-b735-2429ed4513b4.png)
