### PR TITLE
feat(form): hint to always show messages

### DIFF
--- a/server/documents/collections/form.html.eco
+++ b/server/documents/collections/form.html.eco
@@ -972,7 +972,7 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
     <h4 class="ui header">Message</h4>
     <p>A form can contain a <a href="/collections/message.html">message</a></p>
     <div class="ui ignored info message">
-      Any <code>info</code>, <code>error</code>, <code>success</code>, or <code>warning</code> message blocks found inside a form are hidden by default.
+      Any <code>info</code>, <code>error</code>, <code>success</code>, or <code>warning</code> message blocks found inside a form are hidden by default.<br>If you want to force a message inside a form being visible all the time, add the <code>visible</code> class to the message.
     </div>
     <div class="ui form">
       <div class="ui message">


### PR DESCRIPTION
## Description
This PR adds a hint to explain the developer any `message` in a form, which is supposed to be display any time regardless of the form state, should have the `visible` class.

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/129477282-fbb7e1e1-3653-4df3-a8d3-38b8fafcee66.png)

## Closes
https://github.com/fomantic/Fomantic-UI/issues/1196