### PR TITLE
fix(chore): remove cookie link

### DIFF
--- a/server/partials/library-javascript.html.eco
+++ b/server/partials/library-javascript.html.eco
@@ -2,7 +2,6 @@
   <script src="/javascript/library/jquery.js"></script>
 <% #  <script src="/javascript/library/detect.js"></script> %>
   <script src="/javascript/library/clipboard.js"></script>
-  <script src="/javascript/library/cookie.js"></script>
   <script src="/javascript/library/easing.js"></script>
   <script src="/javascript/library/highlight.min.js"></script>
   <script src="/javascript/library/history.js"></script>
@@ -13,7 +12,6 @@
 <% #  <script src="/javascript/library/detect.min.js"></script> %>
   <script src="/javascript/library/jquery.min.js"></script>
   <script src="/javascript/library/clipboard.min.js"></script>
-  <script src="/javascript/library/cookie.min.js"></script>
   <script src="/javascript/library/easing.min.js"></script>
   <script src="/javascript/library/highlight.min.js"></script>
   <script src="/javascript/library/history.min.js"></script>


### PR DESCRIPTION
## Description
We don't need the cookie plugin anymore and already removed it from the nag code and also from the folder.
But we forgot to remove the link in the webpages, so everytime a page loads it throws a 404 error)

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/129763944-745c50b7-6d48-4267-9f51-a78a1db9b67b.png)
