### PR TITLE
fix(form): remove deprecated and unused length prompt

### DIFF
--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -2182,7 +2182,6 @@ type        : 'UI Behavior'
                 doesntContain        : '{name} must contain  \'{ruleValue}\'',
                 doesntContainExactly : '{name} must contain exactly \'{ruleValue}\'',
                 minLength            : '{name} must be at least {ruleValue} characters',
-                length               : '{name} must be at least {ruleValue} characters',
                 exactLength          : '{name} must be exactly {ruleValue} characters',
                 maxLength            : '{name} cannot be longer than {ruleValue} characters',
                 match                : '{name} must match {ruleValue} field',


### PR DESCRIPTION
## Description
Removes the length prompt settings as of https://github.com/fomantic/Fomantic-UI/pull/2087 because its' deprecated since SUI 2.0.6 and not even used in any examples anymore