### PR TITLE
fix(ie11): less needs polyfills

### DIFF
--- a/server/partials/less.html.eco
+++ b/server/partials/less.html.eco
@@ -1,3 +1,4 @@
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Ces2015"></script>
 <script>
 window.less = {
   async        : true,


### PR DESCRIPTION
## Description

The docs page does not completely work anymore for IE11, because LESS (for dynamic theming in the docs pages) unfortunately uses IE11 incompatible functions. By adding a proper polyfill with missing es5/es2015 functions thi is solved. 
I use the https://polyfill.io/ service which will return an empty js file in case a modern browser is used, which does not need polyfills