### PR TITLE
fix(modal): info about approve deny classes in actions

### DIFF
--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -1426,6 +1426,7 @@ themes      : ['Default', 'Material']
           <td>false</td>
           <td>An array of objects. Each object defines an action with properties <code>text</code>,<code>class</code>,<code>icon</code> and <code>click</code>.
             <div class="ui info message">Actions will close the modal by default. Return false from the click handler to prevent that.</div>
+            <div class="ui warning message">If you use any of the approve (approve, ok, positive) or deny (deny, cancel, negative) classnames for the <code>class</code> property, a possibly given click handler will be ignored. In such cases use the <code>onApprove</code> and <code>onDeny</code> callbacks instead</div>
             <div class="code">
             actions: [{
                 text    : 'Wait',

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -1426,7 +1426,7 @@ themes      : ['Default', 'Material']
           <td>false</td>
           <td>An array of objects. Each object defines an action with properties <code>text</code>,<code>class</code>,<code>icon</code> and <code>click</code>.
             <div class="ui info message">Actions will close the modal by default. Return false from the click handler to prevent that.</div>
-            <div class="ui warning message">If you use any of the approve (approve, ok, positive) or deny (deny, cancel, negative) classnames for the <code>class</code> property, a `click` handler will be ignored. In such cases use the <code>onApprove</code> and <code>onDeny</code> callbacks instead</div>
+            <div class="ui warning message">If you use any of the approve (approve, ok, positive) or deny (deny, cancel, negative) classnames for the <code>class</code> property, a <code>click</code> handler will be ignored. In such cases use the <code>onApprove</code> and <code>onDeny</code> callbacks instead</div>
             <div class="code">
             actions: [{
                 text    : 'Wait',

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -1426,7 +1426,7 @@ themes      : ['Default', 'Material']
           <td>false</td>
           <td>An array of objects. Each object defines an action with properties <code>text</code>,<code>class</code>,<code>icon</code> and <code>click</code>.
             <div class="ui info message">Actions will close the modal by default. Return false from the click handler to prevent that.</div>
-            <div class="ui warning message">If you use any of the approve (approve, ok, positive) or deny (deny, cancel, negative) classnames for the <code>class</code> property, a possibly given click handler will be ignored. In such cases use the <code>onApprove</code> and <code>onDeny</code> callbacks instead</div>
+            <div class="ui warning message">If you use any of the approve (approve, ok, positive) or deny (deny, cancel, negative) classnames for the <code>class</code> property, a `click` handler will be ignored. In such cases use the <code>onApprove</code> and <code>onDeny</code> callbacks instead</div>
             <div class="code">
             actions: [{
                 text    : 'Wait',


### PR DESCRIPTION
## Description

This PR adds an info about how to deal with action buttons having any approve/deny classnames set as of https://github.com/fomantic/Fomantic-UI/pull/2108

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/133750851-1c02dd4d-8ab9-4df9-9d2f-aaacab68b029.png)
