### PR TITLE
fix(toast): info about approve deny classes in actions

### DIFF
--- a/server/documents/modules/toast.html.eco
+++ b/server/documents/modules/toast.html.eco
@@ -1094,6 +1094,8 @@ themes      : ['Default']
         <tr>
             <td>actions</td>
             <td>An array of objects. Each object defines an action with properties <code>text</code>,<code>class</code>,<code>icon</code> and <code>click</code>
+                <div class="ui info message">Actions will close the toast by default. Return false from the click handler to prevent that.</div>
+                <div class="ui warning message">If you use any of the approve (approve, ok, positive) or deny (deny, cancel, negative) classnames for the <code>class</code> property, a <code>click</code> handler will be ignored. In such cases use the <code>onApprove</code> and <code>onDeny</code> callbacks instead</div>
                 <div class="code">
                 actions: [{
                     text    : 'Wait',


### PR DESCRIPTION
## Description

Just as in #311 for modal, this PR adds an info about how to deal with action buttons in toasts having any approve/deny classnames set as of https://github.com/fomantic/Fomantic-UI/pull/2112 for the toast module as the logic is identical to modal

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/133862683-f668511d-9a22-4823-b940-e5fbdb83b0f4.png)

