### PR TITLE
fix(icons): improve icon page search

### DIFF
--- a/server/files/javascript/icon.js
+++ b/server/files/javascript/icon.js
@@ -40,11 +40,6 @@ semantic.icon.ready = function() {
         return icons;
       }
     },
-    categoryVisible = function(category) {
-      var rect = category.getBoundingClientRect();
-      var viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
-      return !(rect.bottom < 0 || rect.top - viewHeight >= 0);
-    },
     iconVisible = function (icon) {
       var rect = icon.getBoundingClientRect();
       var viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
@@ -61,17 +56,6 @@ semantic.icon.ready = function() {
             $(this).css('visibility', 'hidden');
           }
         });
-    },
-    checkVisibility = function() {
-      $('.icon.example').each(function() {
-        var element = $(this).get(0);
-    
-        if(categoryVisible(element)) {
-          $(this).css('visibility', 'visible');
-        } else {
-          $(this).css('visibility', 'hidden');
-        }
-      });
     }
   ;
 

--- a/server/files/javascript/icon.js
+++ b/server/files/javascript/icon.js
@@ -45,6 +45,23 @@ semantic.icon.ready = function() {
       var viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
       return !(rect.bottom < 0 || rect.top - viewHeight >= 0);
     },
+    iconVisible = function (icon) {
+      var rect = icon.getBoundingClientRect();
+      var viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
+      return !(rect.bottom < 0 || rect.top - viewHeight >= 0);
+    },
+    checkIconVisibility = function () {
+      $('.icon.example')
+        .find('i.icon')
+        .each(function () {
+          var element = $(this).get(0);
+          if (iconVisible(element)) {
+            $(this).css('visibility', 'visible');
+          } else {
+            $(this).css('visibility', 'hidden');
+          }
+        });
+    },
     checkVisibility = function() {
       $('.icon.example').each(function() {
         var element = $(this).get(0);
@@ -107,10 +124,10 @@ semantic.icon.ready = function() {
   }
 
   // only show icon category when visible on screen
-  $(document).scroll(checkVisibility);
-  $(window).resize(checkVisibility);
-  
-  checkVisibility();
+  $(document).scroll(checkIconVisibility);
+  $(window).resize(checkIconVisibility);
+
+  checkIconVisibility();
   
   
   // check if icon list tab is selected (if so run the check visibility function)
@@ -118,7 +135,7 @@ semantic.icon.ready = function() {
   console.log(tab);
   
   var observer = new MutationObserver(function() {
-    checkVisibility();
+    checkIconVisibility();
   });
   
   observer.observe(tab, {

--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -1575,7 +1575,7 @@ body.progress.animated .ui.progress .bar {
   color: #000000;
 }
 
-#example .icon.example {
+#example .icon.example i.icon {
   visibility: hidden;
 }
 


### PR DESCRIPTION
Improve the search of the icon page when using native browser
find in page function while keeping performance at best.

This new method hides the individual icons rather then the whole
category however it keeps the icon name visible. Once the icon itself
is within view bounds it will then show it. Using this method the
browser will still search the icon names since the text is still on
show.

Fixes #316