### PR TITLE
fix(form): fix dropdown width inside fields inside form field

### DIFF
--- a/server/documents/collections/form.html.eco
+++ b/server/documents/collections/form.html.eco
@@ -122,8 +122,8 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
         </div>
         <div class="six wide field">
           <label>Expiration</label>
-          <div class="two fields">
-            <div class="field">
+          <div class="fields">
+            <div class="eight wide field">
               <select class="ui fluid search dropdown" name="card[expire-month]">
                 <option value="">Month</option>
                 <option value="1">January</option>


### PR DESCRIPTION
## Description

On a 100% OS scale (and 2k resolution) a dropdown menu inside a`fields` which itself is inside a `field` container is sometimes displayd wrong by 1px  . This is because the browser tries to calculate a 100% width for the menu out of its parent containers.

If you have an OS scale of browser zoom or  > 100% the issue is not happening....

## Testcase
- Scale OS to 100%
- Keep your browser zoom to 100% as well
- Open the month dropdown next to the CVC input field in the "shipping information" form
https://fomantic-ui.com/collections/form.html#form

if you compare to the country dropdown, which is only inside a normal `field` the issue is not happening, so this is a special case for the given example only

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/18379884/148971408-83b154fb-ec12-496a-beba-81337fa42f52.png)

### After
![image](https://user-images.githubusercontent.com/18379884/148971462-7c1e8557-e44a-4303-9e08-21c2394cf5c0.png)


