### PR TITLE
feat(card): hint to use click as hover fallback on mobile

### DIFF
--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -264,7 +264,8 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
   <div class="another example">
     <div class="evaluated code" data-type="javascript">
     $('.special.cards .image').dimmer({
-      on: 'hover'
+    // As hover is not working on mobile, you might use click on those devices as fallback
+      on: 'ontouchstart' in document.documentElement ? 'click' : 'hover'
     });
     </div>
     <div class="ui special cards">


### PR DESCRIPTION
## Description
Added a hint how to use a card dimmer on mobile  as discussed in https://github.com/fomantic/Fomantic-UI/discussions/2221#discussioncomment-2124079

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/153053793-e123fc28-4559-4440-ae5d-97228574fa5a.png)
