### PR TITLE
feat(tab): added inverted example and attached hint

### DIFF
--- a/server/documents/modules/tab.html.eco
+++ b/server/documents/modules/tab.html.eco
@@ -99,6 +99,52 @@ themes      : ['Default']
       </div>
     </div>
 
+    <div class="inverted example">
+      <h4 class="ui header">
+        Inverted
+      </h4>
+      <p>A tab can be shown inverted</p>
+      <div class="ui inverted segment">
+        <div class="ui top attached inverted tabular menu">
+          <a class="active item" data-tab="one">Active Tab</a>
+          <a class="item" data-tab="two">Tab 2</a>
+          <a class="item" data-tab="three">Tab 3</a>
+        </div>
+        <div class="ui bottom attached active inverted tab segment" data-tab="one">
+          <p>content one</p>
+        </div>
+        <div class="ui bottom attached inverted tab segment" data-tab="two">
+          <p>content two</p>
+        </div>
+        <div class="ui bottom attached inverted tab segment" data-tab="three">
+          <p>content three</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="inverted example">
+      <h4 class="ui header">
+        Bottom attached menu
+      </h4>
+      <p>You can display the tabular menu at the bottom of the tab segments</p>
+      <div class="ui inverted segment">
+        <div class="ui top attached inverted tab segment" data-tab="one1">
+          <p>content one</p>
+        </div>
+        <div class="ui top attached inverted tab segment" data-tab="two1">
+          <p>content two</p>
+        </div>
+        <div class="ui top attached inverted tab segment active" data-tab="three1">
+          <p>content three</p>
+        </div>
+        <div class="ui bottom attached inverted tabular menu">
+          <a class="item" data-tab="one1">Active Tab</a>
+          <a class="item" data-tab="two1">Tab 2</a>
+          <a class="item active" data-tab="three1">Tab 3</a>
+        </div>
+      </div>
+    </div>
+
   </div>
 
   <div class="ui tab" data-tab="examples">
@@ -518,6 +564,20 @@ themes      : ['Default']
         <h4 class="ui header">Default Tabs</h4>
         <p>After any tab is opened it will look for a default tab to open inside of the current tab. This is the first tab that begins with the same stem url as the parent tab. For example a tab with the path <code>data-tab="home"</code> might open a tab automatically <code>data-tab="/home/inbox"</code>.</p>
         <p>This will happen recursively for every tab open, allowing as many levels of tabs as you like.</p>
+      </div>
+      <div class="ignored ui warning message">
+        <h4 class="ui header">Using tab segments</h4>
+        <p>To avoid possible CSS issues when using <code>attached segments</code> you should wrap your tabular menu tab and related attached tab segments into a dedicated DOM node, for example a <code>ui segment</code></p>
+       <div class="code" data-type="html">
+          <div class="ui basic segment">
+            <div class="ui top attached tabular menu">
+              <a class="item" data-tab="entries">Tab menu item</a>
+            </div>
+            <div class="ui bottom attached tab segment" data-tab="entries">
+              <p>Tab content</p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/server/files/javascript/tab.js
+++ b/server/files/javascript/tab.js
@@ -81,6 +81,8 @@ semantic.dropdown.ready = function() {
     })
   ;
 
+  $('.inverted.example .menu > .item').tab();
+
 };
 
 

--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -520,7 +520,7 @@ blockquote .author {
   display: none !important;
 }
 #example .main.container .introduction p,
-#example .main.container .tab > p,
+#example .main.container > .tab > p,
 #example .main.container .example > p,
 #example .main.container > p {
   font-size: 16px;


### PR DESCRIPTION
## Description
Added example for `inverted` and `bottom attached menu` as of https://github.com/fomantic/Fomantic-UI/pull/2082

I also added a hint to wrap a tabular menu havont attached tab segments as of https://github.com/fomantic/Fomantic-UI/pull/1480

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/156932705-bcb345e5-b48a-465e-a14a-bb73c8d8457c.png)
![image](https://user-images.githubusercontent.com/18379884/156932711-534cda1d-9177-45fb-9fe2-ef56cde3f234.png)
