### PR TITLE
fix(card): buttons in card dont need attached class

### DIFF
--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -402,7 +402,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
             Elliot Fu is a film-maker from New York.
           </div>
         </div>
-        <div class="ui bottom attached button">
+        <div class="ui button">
           <i class="add icon"></i>
           Add Friend
         </div>
@@ -414,7 +414,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
             Veronika Ossi is a set designer living in New York who enjoys kittens, music, and partying.
           </div>
         </div>
-        <div class="ui bottom attached button">
+        <div class="ui button">
           <i class="add icon"></i>
           Add Friend
         </div>
@@ -426,7 +426,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
             Jenny is a student studying Media Management at the New School
           </div>
         </div>
-        <div class="ui bottom attached button">
+        <div class="ui button">
           <i class="add icon"></i>
           Add Friend
         </div>


### PR DESCRIPTION
## Description
[Card buttons](https://fomantic-ui.com/views/card.html#buttons), supposed to be shown at top or button, do not need the `attached` class. Infact adding that class will make the button appear overlaying the card to the sides.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/18379884/162255066-cd93482e-a943-4b78-9278-46cc637866c7.png)

### After
![image](https://user-images.githubusercontent.com/18379884/162255125-5166465f-e2a0-4968-b547-286592d228dd.png)

## Closes
https://github.com/fomantic/Fomantic-UI/issues/1865