### PR TITLE
fix(emoji): show some features in higher size

### DIFF
--- a/server/documents/elements/emoji.html.eco
+++ b/server/documents/elements/emoji.html.eco
@@ -68,7 +68,7 @@ themes      : ['Default']
     <div class="example">
       <h4 class="ui header">Disabled</h4>
       <p>An emoji can show that it is disabled</p>
-      <div class="ui basic segment">
+      <div class="ui basic massive segment">
           <em data-emoji="anguished" class="disabled"></em>
       </div>
     </div>
@@ -76,7 +76,7 @@ themes      : ['Default']
     <div class="example">
       <h4 class="ui header">Loading</h4>
       <p>An emoji can be used as a simple loader</p>
-      <div class="ui basic segment">
+      <div class="ui basic massive segment">
           <em data-emoji="angel" class="loading"></em>
           <em data-emoji="blush" class="loading"></em>
           <em data-emoji="grin" class="loading"></em>
@@ -114,7 +114,7 @@ themes      : ['Default']
     <div class="example">
       <h4 class="ui header">Link</h4>
       <p>An emoji can be formatted as a link</p>
-      <div class="ui basic segment">
+      <div class="ui basic massive segment">
           <em data-emoji="slight_smile" class="link"></em>
       </div>
     </div>


### PR DESCRIPTION
## Description
By fixing the emojie/flag default line height by https://github.com/fomantic/Fomantic-UI/pull/2337 some emoji examples appear too small

## Before
![image](https://user-images.githubusercontent.com/18379884/164995039-224eef3d-b158-41f3-8d9b-d998993e2dbb.png)

## After
![image](https://user-images.githubusercontent.com/18379884/164995047-3859ee04-1edf-41b2-8208-e30b66cf734d.png)
