### PR TITLE
feat(dropdown): make behavior usage more clear

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -3057,12 +3057,21 @@ themes      : ['Default', 'GitHub', 'Material']
     $('.your.element')
       .dropdown('behavior name', argumentOne, argumentTwo)
     ;
+
+    // For example using the below mentioned 'clear(preventChangeTrigger)'
+    $('.ui.dropdown')
+      .dropdown('clear', true)
+    ;
+    // Using the same but omit the default value for the preventChangeTrigger argument (which is false)
+    $('.ui.dropdown')
+      .dropdown('clear')
+    ;
     </div>
 
     <table class="ui definition sortable celled table segment">
       <thead>
         <tr>
-          <th>Behavior</th>
+          <th>Behavior (arguments)</th>
           <th>Description</th>
         </tr>
       </thead>
@@ -3119,8 +3128,8 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>Saves current text and value as new defaults (for use with restore)</td>
         </tr>
         <tr>
-          <td>set selected(value,$selectedItem,preventChangeTrigger)</td>
-          <td>Sets value as selected. <code>$selectedItem</code> is used internally and can be ignored. Set <code>preventChangeTrigger</code> to <code>true</code> to omit the change event</td>
+          <td>set selected(value,preventChangeTrigger)</td>
+          <td>Sets value as selected. Set <code>preventChangeTrigger</code> to <code>true</code> to omit the change event (default: <code>false</code>).</td>
         </tr>
         <tr>
           <td>remove selected(value)</td>
@@ -3139,8 +3148,8 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>Sets dropdown text to a value</td>
         </tr>
         <tr>
-          <td>set value (value,text,$selected,preventChangeTrigger)</td>
-          <td>Sets dropdown input to value (does not update display state). <code>text</code> and <code>$selected</code> are used internally and can be ignored. Set <code>preventChangeTrigger</code> to <code>true</code> to omit the change event</td>
+          <td>set value (value,preventChangeTrigger)</td>
+          <td>Sets dropdown input to value (does not update display state). Set <code>preventChangeTrigger</code> to <code>true</code> to omit the change event (default: <code>false</code>).</td>
         </tr>
         <tr>
           <td>get text</td>
@@ -3148,7 +3157,11 @@ themes      : ['Default', 'GitHub', 'Material']
         </tr>
         <tr>
           <td>get value</td>
-          <td>Returns current dropdown input value</td>
+          <td>Returns current dropdown input value. When the dropdown was created out of a <code>select</code> tag, the value will always be an array, otherwise a string (delimited when multiple)</td>
+        </tr>
+        <tr>
+          <td>get values</td>
+          <td>Returns current dropdown input values as array. Useful for <a href="#multiple-selections">multiple selection</a> dropdowns regardless if made out of a div or select</td>
         </tr>
         <tr>
           <td>get item(value)</td>


### PR DESCRIPTION
## Description

This adds a bit more of clarifications how to use the complex dropdown behaviors.
It also reflects the changes from https://github.com/fomantic/Fomantic-UI/pull/2326 , so the internally used arguments are not needed to be provided.
I also added `get values`, to describe the difference to `get value` between values in div (string) or select (array) dropdowns

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/165639148-1fe074b6-19aa-41dd-8f04-735db93303f0.png)
![image](https://user-images.githubusercontent.com/18379884/165639203-b5d496ef-4c6b-4762-817c-0e5b0deaac85.png)
![image](https://user-images.githubusercontent.com/18379884/165639237-328fb96e-ff9e-4992-a5e0-e1c9ac2c5a49.png)


## Closes
#245 