### PR TITLE
feat(dropdown): add values examples for change values behavior

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -3072,7 +3072,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>Recreates dropdown menu from passed values. <code>values</code> should be an object with the following structure: <code>{ values: [ {value, text, name} ] }</code>.</td>
         </tr>
           <td>change values (values)</td>
-          <td>Changes dropdown to use new values</td>
+          <td>Changes dropdown to use new values. <code>values</code> structure: <code>{ [ {value, text, name} ] }</code>.</td>
         </tr>
         <tr>
           <td>refresh</td>

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -3072,7 +3072,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>Recreates dropdown menu from passed values. <code>values</code> should be an object with the following structure: <code>{ values: [ {value, text, name} ] }</code>.</td>
         </tr>
           <td>change values (values)</td>
-          <td>Changes dropdown to use new values. <code>values</code> structure: <code>{ [ {value, text, name} ] }</code>.</td>
+          <td>Changes dropdown to use new values. <code>values</code> structure: <code>[ {value, text, name} ]</code>.</td>
         </tr>
         <tr>
           <td>refresh</td>


### PR DESCRIPTION
It is clearer that there is an example of how values ​​structure.

Without example I thought that this is the way to change values (like `setup menu(values)`):

<kbd>Not working</kbd>
```
$('.ui.dropdown').dropdown('change values', {
  values: [
    {
      name: 'Male (Not working example)',
      value: 'male',
    },
  ]
});
```
<kbd>working</kbd>

```
$('.ui.dropdown').dropdown('change values', [
  {
    name: 'Male',
    value: 'male',
  },
  {
    name: 'Female',
    value: 'female',
  }
]);
```