### PR TITLE
fix(search, accordion): fix easing info

### DIFF
--- a/server/documents/modules/accordion.html.eco
+++ b/server/documents/modules/accordion.html.eco
@@ -721,8 +721,8 @@ themes      : ['Default', 'Chubby']
         </tr>
         <tr>
           <td>easing</td>
-          <td>easeInOutQuint</td>
-          <td>Easing of opening animation. EaseInOutQuint is included with accordion, for additional options you must include <a href="http://gsgd.co.uk/sandbox/jquery/easing/">easing equations</a>.</td>
+          <td>easeOutQuad</td>
+          <td>Easing of opening animation. EaseOutQuad is included with accordion, for additional options you must include <a href="http://gsgd.co.uk/sandbox/jquery/easing/">easing equations</a>.</td>
         </tr>
       </tbody>
     </table>

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -854,7 +854,7 @@ type        : 'UI Module'
           <td>
             easeOutExpo
           </td>
-          <td>Easing equation when using fallback Javascript animation</td>
+          <td>Easing equation when using fallback Javascript animation. EaseOutExpo is included with search, for additional options you must include <a href="http://gsgd.co.uk/sandbox/jquery/easing/">easing equations</td>
         </tr>
         <tr>
           <td>ignoreDiacritics</td>


### PR DESCRIPTION
## Description
The easing info was wrong or missing for search and accordion 
- accordion has a different default easing than written in the docs,
- additional link added to search