### PR TITLE
feat(flyout): short $. notation

### DIFF
--- a/server/documents/modules/flyout.html.eco
+++ b/server/documents/modules/flyout.html.eco
@@ -220,7 +220,7 @@ themes      : ['Default']
       <h4 class="ui header">Via Javascript properties</h4>
       <p>You can create temporary flyouts without the need to create markup on your own. Temporary flyouts will be removed from the DOM once closed by default if there isn't a custom <code>onHidden</code> callback given.</p>
       <div class="code" data-demo="true">
-        $('body').flyout({
+        $.flyout({
           debug: true,
           verbose: true,
           autoShow: true,


### PR DESCRIPTION
Since `flyout` is a new 2.9.0 component, we should only display the short `.$` notation when creating a flyout with js properties.

![image](https://user-images.githubusercontent.com/7557689/190648677-5f6853c0-12ec-4b95-a49d-ef69a521e1d1.png)
