### PR TITLE
fix(build): clarify directory used for build

### DIFF
--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -90,7 +90,7 @@ type        : 'Main'
       This is <code>semantic/</code> by default.
     </p>
     <div class="ignored code" data-type="bash">
-      $ cd node_modules/fomantic-ui
+      $ cd semantic/
       $ npx gulp build
     </div>
     <p>


### PR DESCRIPTION
Recently added Fomantic UI to one of my projects. I believe this is the directory to be accessed for the build command, assuming the directory was not changed in `semantic.json`. I think the `node_modules/fomantic-ui` directory would work as well, but if you installed Fomantic using `npx gulp install`, you might want to start running the build command from `semantic/` directory instead, especially if you want to make changes to it in the future.