### PR TITLE
fix(flyout): add close icons

### DIFF
--- a/server/partials/demo-flyout.html
+++ b/server/partials/demo-flyout.html
@@ -22,18 +22,22 @@
 </div>
 
 <div class="ui top position flyout">
+  <i class="close icon"></i>
   <div class="content" style="text-align: center;">I'm on top</div>
 </div>
 
 <div class="ui bottom position flyout">
+  <i class="close icon"></i>
   <div class="content" style="text-align: center;">I'm on bottom</div>
 </div>
 
 <div class="ui left position flyout">
+  <i class="close icon"></i>
   <div class="content">I'm on left</div>
 </div>
 
 <div class="ui right position flyout">
+  <i class="close icon"></i>
   <div class="content">I'm on right</div>
 </div>
 


### PR DESCRIPTION
## Description

The multi flyout position example was not able to be closed on mobile, because the dimmer is not visible anymore.
This PR simply adds close icons to each flyout, so it's usable again

## Closes
#388 