### PR TITLE
feat(segment): wrapping alias

### DIFF
--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -301,11 +301,14 @@ themes      : ['default', 'GitHub']
       </div>
   </div>
   <div class="example">
-    <h4 class="ui header">Horizontal stackable Segments
-    <div class="ui black label">New in 2.7.2</div>
+    <h4 class="ui header">Horizontal wrapping Segments
+    <div class="ui black label">New in 2.9.3</div>
     </h4>
+    <div class="ui ignored warning message">
+    There also exists a <code>horizontal stackable segments</code> alias but that alias is deprecated by 2.9.3 and will be removed in 2.10.0
+    </div>
     <p>A horizontal segment group can automatically stack on smaller screens</p>
-    <div class="ui horizontal stackable segments">
+    <div class="ui horizontal wrapping segments">
       <div class="ui segment">
         Segment One
       </div>

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -307,7 +307,7 @@ themes      : ['default', 'GitHub']
     <div class="ui ignored warning message">
     There also exists a <code>horizontal stackable segments</code> alias but that alias is deprecated by 2.9.3 and will be removed in 2.10.0
     </div>
-    <p>A horizontal segment group can automatically stack on smaller screens</p>
+    <p>A horizontal segment group can automatically wrap their segments on smaller screens</p>
     <div class="ui horizontal wrapping segments">
       <div class="ui segment">
         Segment One


### PR DESCRIPTION
## Description

Making `horizontal stackable` deprecated and replaced by `horizontal wrapping` segment as of https://github.com/fomantic/Fomantic-UI/pull/2694

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/217629292-deefa4b9-139f-4054-84ab-12f3fecf7fce.png)
