### PR TITLE
feat(slider): minRange, maxRange, restrictedLabels, tooltip

### DIFF
--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -123,7 +123,7 @@ themes      : ['Default']
     </div>
     <div class="example">
       <h4 class="ui header">Tooltip Position</h4>
-      <p>A tooltip can be shown at a specific position relative to the element via via the <code>data-position</code> attribute.</p>
+      <p>A tooltip can be shown at a specific position relative to the element via the <code>data-position</code> attribute.</p>
       <div class="ui button" data-tooltip="Add users to your feed" data-position="top left">
         Top Left
       </div>
@@ -259,6 +259,14 @@ themes      : ['Default']
         -two
         -three" data-position="bottom center" data-variation="multiline">
     Multiline tooltip
+      </div>
+    </div>
+
+    <div class="example">
+      <h4 class="ui header">Visible Tooltip <div class="ui black label">New in 2.9.3</div></h4>
+      <p>A tooltip can be shown visible all the time by adding <code>visible</code> to the <code>data-variation</code> attribute.</p>
+      <div class="ui button" data-tooltip="I am visible all the time" data-variation="visible" data-position="right center">
+        Important Button
       </div>
     </div>
 

--- a/server/documents/modules/slider.html.eco
+++ b/server/documents/modules/slider.html.eco
@@ -52,6 +52,23 @@ themes      : ['Default']
     </div>
 
     <div class="example">
+        <h4 class="ui header">Restricted Labels <div class="ui black label">New in 2.9.3</div></h4>
+        <p>You can restrict the display of labels to only the ones you want</p>
+        <div class="ui labeled ticked slider" id="restrictedlabelsslider"></div>
+    </div>
+    <div class="code" data-type="javascript">
+      $('.ui.slider')
+        .slider({
+            restrictedLabels: [0, 10, 15, 35, 80, 90, 100],
+            min: 0,
+            max: 100,
+            step: 0,
+            autoAdjustLabels: false
+        })
+      ;
+    </div>
+
+    <div class="example">
         <h4 class="ui header">Custom interpreted labels</h4>
         <p>You can provide a function which returns a custom label according to the label value</p>
         <div class="ui labeled ticked slider" id="interpretedlabel"></div>
@@ -83,6 +100,23 @@ themes      : ['Default']
           start: 10,
           end: 90,
           step: 5
+        })
+      ;
+      </div>
+      <div class="another example">
+      <p>A range slider can be limited to how far the distance between the two thumbs can be</p>
+      <div class="ui labeled ticked range slider" id="slider-range-minmax"></div><br>
+    </div>
+    <div class="code" data-type="javascript">
+      $('.ui.range.slider')
+        .slider({
+          min: 5,
+          max: 100,
+          start: 10,
+          end: 50,
+          minRange: 10,
+          maxRange: 40,
+          step: 0
         })
       ;
       </div>
@@ -316,6 +350,16 @@ themes      : ['Default']
           <td>The second value to set in case of a range slider</td>
         </tr>
         <tr>
+          <td>minRange</td>
+          <td>false</td>
+          <td>Makes sure that the two thumbs of a range slider always need to have a difference of the given value</td>
+        </tr>
+        <tr>
+          <td>maxRange</td>
+          <td>false</td>
+          <td>Makes sure that the two thumbs of a range slider don't exceed a difference of the given value</td>
+        </tr>
+        <tr>
           <td>labelType</td>
           <td>number</td>
           <td>The type of label to display for a labeled slider. Can be <code>number</code> or <code>letter</code></td>
@@ -334,9 +378,17 @@ themes      : ['Default']
           </td>
         </tr>
         <tr>
+            <td>restrictedLabels</td>
+            <td>[]</td>
+            <td>An array of label values which restrict the displayed labels to only those which are defined</td>
+        </tr>
+        <tr>
           <td>showLabelTicks</td>
           <td>false</td>
-          <td>Show ticks on a labeled slider</td>
+          <td>Show ticks on a labeled slider.<br>
+                <code>'always'</code>will always show the ticks for all labels (even if not shown)<br>
+                <code>true</code> will display the ticks only if the related label is also shown
+          </td>
         </tr>
         <tr>
           <td>smooth</td>

--- a/server/documents/modules/slider.html.eco
+++ b/server/documents/modules/slider.html.eco
@@ -125,7 +125,7 @@ themes      : ['Default']
     <div class="example">
       <h4 class="ui header">Disabled</h4>
       <p>A slider can appear disabled</p>
-      <div class="ui disabled slider" id="slider-2"></div>
+      <div class="ui disabled slider"></div>
     </div>
 
     <div class="example">
@@ -140,6 +140,34 @@ themes      : ['Default']
       <h4 class="ui header">Reversed</h4>
       <p>A slider can be reversed</p>
       <div class="ui reversed slider"></div>
+    </div>
+
+    <div class="example">
+      <h4 class="ui header">Thumb Tooltips <div class="ui black label">New in 2.9.3</div></h4>
+      <p>The slider thumbs can show a tooltip on hover containing the current value</p>
+      <div class="ui slider" id="slider-tooltip-1"></div>
+    </div>
+    <div class="code" data-type="javascript">
+      $('.ui.slider')
+        .slider({
+          showThumbTooltip: true
+        })
+      ;
+    </div>
+    <div class="another example">
+      <p>The tooltips can stay visible all the time and can be customized by the <code>tooltipConfig</code> setting.<br>Refer to <a href="/modules/popup#tooltip">Toolip Variations</a> for possible values.</p>
+      <div class="ui range slider" id="slider-tooltip-2"></div>
+    </div>
+    <div class="code" data-type="javascript">
+      $('.ui.slider')
+        .slider({
+          showThumbTooltip: true,
+          tooltipConfig: {
+            position: 'bottom center',
+            variation: 'small visible green'
+          }
+        })
+      ;
     </div>
 
     <div class="example">
@@ -320,7 +348,7 @@ themes      : ['Default']
     <table class="ui sortable celled definition table">
       <thead>
         <th>Setting</th>
-        <th class="four wide">Default</th>
+        <th class="five wide">Default</th>
         <th>Description</th>
       </thead>
       <tbody>
@@ -381,6 +409,23 @@ themes      : ['Default']
             <td>restrictedLabels</td>
             <td>[]</td>
             <td>An array of label values which restrict the displayed labels to only those which are defined</td>
+        </tr>
+        <tr>
+            <td>showThumbTooltip</td>
+            <td>false</td>
+            <td>Whether a tooltip should be shown to the thumb(s) on hover. Will contain the current slider value.</td>
+        </tr>
+        <tr>
+            <td>tooltipConfig</td>
+            <td>
+              <div class="code">
+                {
+                    position: 'top center',
+                    variation: 'tiny black'
+                }
+              </div>
+            </td>
+            <td>Tooltip configuration used when <code>showThumbTooltip</code> is true<br>Refer to <a href="/modules/popup#tooltip">Tooltip Variations</a> for possible values.</td>
         </tr>
         <tr>
           <td>showLabelTicks</td>

--- a/server/documents/modules/slider.html.eco
+++ b/server/documents/modules/slider.html.eco
@@ -155,7 +155,7 @@ themes      : ['Default']
       ;
     </div>
     <div class="another example">
-      <p>The tooltips can stay visible all the time and can be customized by the <code>tooltipConfig</code> setting.<br>Refer to <a href="/modules/popup#tooltip">Toolip Variations</a> for possible values.</p>
+      <p>The tooltips can stay visible all the time and can be customized by the <code>tooltipConfig</code> setting.<br>Refer to <a href="/modules/popup#tooltip">Tooltip Variations</a> for possible values.</p>
       <div class="ui range slider" id="slider-tooltip-2"></div>
     </div>
     <div class="code" data-type="javascript">

--- a/server/files/javascript/slider.js
+++ b/server/files/javascript/slider.js
@@ -4,7 +4,7 @@ semantic.slider = {};
 semantic.slider.ready = function() {
   // selector cache
   var
-    $slider     = $('.ui.slider')
+    $slider     = $('.ui.slider:not([id])')
   ;
   $slider
     .slider({
@@ -63,6 +63,23 @@ semantic.slider.ready = function() {
         autoAdjustLabels: false
     })
   ;
+
+    $('#slider-tooltip-1')
+        .slider({
+            showThumbTooltip: true,
+            step: 0
+        })
+    ;
+    $('#slider-tooltip-2')
+        .slider({
+            showThumbTooltip: true,
+            tooltipConfig: {
+                position: 'bottom center',
+                variation: 'small visible green'
+            },
+            step: 0
+        })
+    ;
 
   $('#slider-custom-step')
     .slider({

--- a/server/files/javascript/slider.js
+++ b/server/files/javascript/slider.js
@@ -13,7 +13,7 @@ semantic.slider.ready = function() {
       start: 5
     })
   ;
-  
+
   $('#slider-1')
     .slider({
       min: 0,
@@ -40,6 +40,27 @@ semantic.slider.ready = function() {
           $('#range-slider-input-1').val('|' + secondVal + " - " + firstVal + '| = ' + range);
         }
       }
+    })
+  ;
+  $('#slider-range-minmax')
+    .slider({
+        min: 5,
+        max: 100,
+        start: 10,
+        end: 50,
+        minRange: 10,
+        maxRange: 40,
+        step: 0
+    })
+  ;
+
+  $('#restrictedlabelsslider')
+    .slider({
+        restrictedLabels: [0, 10, 15, 35, 80, 90, 100],
+        min: 0,
+        max: 100,
+        step: 0,
+        autoAdjustLabels: false
     })
   ;
 


### PR DESCRIPTION
## Description
Info about restrictedLabels, minRange, maxRange, tooltip as of https://github.com/fomantic/Fomantic-UI/pull/2726
Also added new `visible` tooltip variation

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/222932278-4b8d47df-34f5-4f55-8994-023f2202fe4c.png)
![image](https://user-images.githubusercontent.com/18379884/222932293-9ef50b2d-0460-4351-a3f0-4f7b0007a7d4.png)
![image](https://user-images.githubusercontent.com/18379884/222932344-6a0f5482-acbc-4b70-87f9-deb63af6c040.png)
![image](https://user-images.githubusercontent.com/18379884/222983845-35168513-70ca-481a-a125-c7be7bb88958.png)
![image](https://user-images.githubusercontent.com/18379884/222980734-e4fc221d-1d52-4a57-b571-945a203e0102.png)
![image](https://user-images.githubusercontent.com/18379884/222980765-f9d27559-2da7-424c-9c10-612912d4bad7.png)

