### PR TITLE
feat(chore): generate new and word order labels from data attribute

### DIFF
--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -159,8 +159,8 @@ type        : 'UI Behavior'
         <div class="ui error message"></div>
       </div>
     </form>
-    <div class="color example">
-      <h4 class="ui header">Passing Parameters to Rules <div class="ui horizontal teal label">New in 2.2.3</div></h4>
+    <div class="color example" data-since="2.2.3">
+      <h4 class="ui header">Passing Parameters to Rules</h4>
       <p>Typically rules that include a parameter are written <code>minLength[2]</code> with the value being passed in as brackets.</p>
       <p>If passing in properties as a string is not ideal, or if you are pulling values from another javascript variable, it might make sense to consider using <code>value</code> to pass in the rule value.</p>
       <div class="ignored code">
@@ -1436,9 +1436,9 @@ type        : 'UI Behavior'
 
     <h2 class="ui dividing header">Form Examples</h2>
 
-    <div class="add example">
+    <div class="add example" data-since="2.2.11">
       <h4 class="ui header">
-        Adding Rules Programmatically <div class="ui teal label">New in 2.2.11</div>
+        Adding Rules Programmatically
       </h4>
       <p>You can use the special behaviors <code>add field/rule</code>, <code>remove rule</code> and <code>remove field</code> to dynamically add or remove fields or rules. </p>
       <div class="ui ignored info message">
@@ -1575,10 +1575,9 @@ type        : 'UI Behavior'
       </form>
     </div>
 
-    <div class="depends example">
+    <div class="depends example" data-since="2.2">
       <h4 class="ui header">
         Dependent Fields
-        <div class="ui teal horizontal label">New in 2.2</div>
       </h4>
       <p>You can specify validation fields to only be used when other fields are present. Simply add <code>depends: 'identifier'</code> with the ID of the field that must be non-blank for this rule to evaluate.</p>
       <div class="ignored code">

--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -353,7 +353,7 @@ type        : 'UI Behavior'
         <p>Validation rules are a set of conditions required to validate a field</p>
       <div class="ui info message">Validation rules are found in <code>$.fn.form.settings.rules</code>, to add new global validation rules, modify <code>$.fn.form.settings.rules</code> to include your function.</div>
       <div class="ui info message">To pass parameters to a rule, use bracket notation in your settings object. For example <code>type: 'not[dog]'</code></div>
-      <div class="ui info message">Despite the global setting <code>shouldTrim</code> you can optionally specify to trim/not trim values before validation by adding <code>shouldTrim:true</code> or <code>shouldTrim:false</code> to each rule <span class="ui tiny black label">New in 2.8.8</span></div>
+      <div class="ui info message">Despite the global setting <code>shouldTrim</code> you can optionally specify to trim/not trim values before validation by adding <code>shouldTrim:true</code> or <code>shouldTrim:false</code> to each rule <span class="ui tiny teal label">New in 2.8.8</span></div>
 
       <h3 class="ui header"><a href="#empty">Empty</a></h3>
       <table class="ui celled sortable basic table segment">
@@ -500,7 +500,7 @@ type        : 'UI Behavior'
             <td><code>maxLength[50]</code></td>
           </tr>
           <tr>
-            <td>size <span class="ui mini black label">New in 2.9.2</span></td>
+            <td>size <span class="ui mini teal label">New in 2.9.2</span></td>
             <td>A field has a size between min and max characters</td>
             <td><code>size[6..12]</code></td>
           </tr>
@@ -1958,19 +1958,19 @@ type        : 'UI Behavior'
         <td>Returns true/false whether a form passes its validation rules</td>
       </tr>
       <tr>
-        <td>add rule(field, rules)<div class="ui label">New in 2.2.11</div></td>
+        <td>add rule(field, rules)<div class="ui teal label">New in 2.2.11</div></td>
         <td>Adds rule to existing rules for field, also aliased as <code>add field</code></td>
       </tr>
       <tr>
-        <td>add fields(fields) <div class="ui label">New in 2.2.11</div></td>
+        <td>add fields(fields) <div class="ui teal label">New in 2.2.11</div></td>
         <td>Adds fields object to existing fields</td>
       </tr>
       <tr>
-        <td>remove rule(field, rules)<div class="ui label">New in 2.2.11</div></td>
+        <td>remove rule(field, rules)<div class="ui teal label">New in 2.2.11</div></td>
         <td>Removes specific rule from field leaving other rules</td>
       </tr>
       <tr>
-        <td>remove field(field)<div class="ui label">New in 2.2.11</div></td>
+        <td>remove field(field)<div class="ui teal label">New in 2.2.11</div></td>
         <td>Remove all validation for a field</td>
       </tr>
       <tr>
@@ -2050,7 +2050,7 @@ type        : 'UI Behavior'
         <td>Automatically adds the "empty" rule or automatically checks a checkbox for all fields with classname or attribute <code>required</code></td>
       </tr>
       <tr>
-        <td>set optional(identifier, bool = true)<div class="ui label">New in 2.8.8</div></td>
+        <td>set optional(identifier, bool = true)<div class="ui teal label">New in 2.8.8</div></td>
         <td>Set or unset matching fields as optional</td>
       </tr>
     </table>
@@ -2096,7 +2096,7 @@ type        : 'UI Behavior'
             <td>Adds inline error on field validation error</td>
           </tr>
           <tr>
-            <td>shouldTrim <div class="ui label">New in 2.4.0</div></td>
+            <td>shouldTrim <div class="ui teal label">New in 2.4.0</div></td>
             <td>true</td>
             <td>Whether or not the form should trim the value before validating</td>
           </tr>
@@ -2128,7 +2128,7 @@ type        : 'UI Behavior'
             <td>Whether fields with classname or attribute <code>required</code> should automatically add the "empty" rule or automatically checks checkbox fields</td>
           </tr>
           <tr>
-            <td>errorFocus<div class="ui label">New in 2.8.8</div></td>
+            <td>errorFocus<div class="ui teal label">New in 2.8.8</div></td>
             <td>true</td>
             <td>Whether, on an invalid form validation, it should automatically focus either the first error field (<code>true</code>) or a specific dom node (Use a unique selector string such as <code>.ui.error.message</code> or <code>#myelement</code>) or nothing (<code>false</code>)</td>
           </tr>

--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -1877,7 +1877,7 @@ type        : 'UI Behavior'
       </form>
     </div>
 
-    <div class="dirty example">
+    <div class="dirty example" data-since="2.7.5">
       <h4 class="ui header">Dirty / Clean state</h4>
       <p>
         When initialized, form has a <em>clean</em> state that record all field values. Once at least one field is modified, form enter in <em>dirty</em> state, that can be caught through the <code>onDirty</code> event.

--- a/server/documents/behaviors/visibility.html.eco
+++ b/server/documents/behaviors/visibility.html.eco
@@ -961,10 +961,9 @@ type        : 'UI Behavior'
       </table>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.2">
       <h4 class="ui header">
         Image Callbacks
-        <div class="ui teal horizontal label">New in 2.2</div>
       </h4>
       <p>Callbacks that occur only when using <a href="#lazy-loading-images"><code>type: 'fixed'</code></a></p>
 
@@ -990,11 +989,10 @@ type        : 'UI Behavior'
         </tbody>
       </table>
     </div>
-    <div class="no example">
+    <div class="no example" data-since="2.2">
 
       <h4 class="ui header">
         Fixed Callbacks
-        <div class="ui teal horizontal label">New in 2.2</div>
       </h4>
       <p>Callbacks that occur only when using <a href="#fixing-content-to-viewport"><code>type: 'fixed'</code></a></p>
 

--- a/server/documents/collections/breadcrumb.html.eco
+++ b/server/documents/collections/breadcrumb.html.eco
@@ -106,7 +106,7 @@ themes      : ['Default']
 
   <h2 class="ui dividing header">Variations</h2>
 
-  <div class="example" data-class="inverted">
+  <div class="example" data-since="2.7.5" data-class="inverted">
     <h4 class="ui header">Inverted</h4>
     <p>A breadcrumb can be inverted</p>
     <div class="ui inverted segment">

--- a/server/documents/collections/form.html.eco
+++ b/server/documents/collections/form.html.eco
@@ -962,7 +962,7 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
           <div class="ui input left icon">
             <i class="calendar icon"></i>
             <input type="text" placeholder="Pick up a date" name="date">
-          </div>        
+          </div>
         </div>
       </div>
     </div>
@@ -1369,7 +1369,7 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
     </div>
   </div>
 
-  <div class="example" data-use-content="true">
+  <div class="example" data-class="!equal width" data-use-content="true">
     <h4 class="ui header">Equal Width Form</h4>
     <p>Forms can automatically divide fields to be equal width</p>
     <div class="ui equal width form">

--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -186,7 +186,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="highlighted example" data-use-content="true" data-class="wide">
+    <div class="highlighted example" data-use-content="true" data-class="!eight wide, wide">
       <h4 class="ui header">Column Widths</h4>
       <p>Column widths can be specified using <a href="#column-width"><code>(x) wide</code></a> class names. If a column cannot fit in a row it will automatically flow to the next row</p>
       <div class="ui grid">
@@ -298,7 +298,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="colored example" data-use-content="true" data-class="colored, padded">
+    <div class="colored example" data-use-content="true" data-class="colors, padded">
       <h4 class="ui header">Colored</h4>
       <p>Grids can use named <a href="#colored"><b>colors</b> variations</a> to add background colors, but only with <a href="#padded"><code>padded grid</code></a> that do not include negative margins.</p>
       <p>To include a color that is not available in the default palette its perfectly fine to use CSS</p>
@@ -326,7 +326,7 @@ themes      : ['Default']
     </div>
 
 
-    <div class="highlighted example" data-class="equal width">
+    <div class="highlighted example" data-class="!equal width">
       <h4 class="ui header">Automatic Column Count</h4>
       <p>The <a href="#equal-width"><code>equal width</code></a> variation will automatically divide column width evenly. This is useful with dynamic content where you do not know the column count in advance.</p>
       <div class="ui equal width grid">
@@ -692,7 +692,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-use-content="true" data-class="wide">
+    <div class="example" data-use-content="true" data-class="!four wide,wide">
       <h4 class="ui header">Column Width</h4>
       <p>A column can vary in width taking up more than a single grid column.</p>
       <div class="ui grid">
@@ -944,7 +944,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-class="very compact, compact">
+    <div class="example" data-class="!very compact, compact">
       <h4 class="ui header">Compact</h4>
       <p>A grid can appear compact with no or very little padding</p>
 
@@ -1027,7 +1027,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-use-content="true">
+    <div class="example" data-class="colors" data-use-content="true">
       <h4 class="ui header">Colored</h4>
       <p>A row or column can be colored</p>
       <div class="ui five column padded grid">

--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -352,7 +352,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-use-content="true" data-class="!left floated, !right aligned, !right floated,  !left aligned, !center aligned, !sixteen wide">
+    <div class="example" data-use-content="true" data-class="!left floated, !right aligned, !right floated, !left aligned, !center aligned, !sixteen wide">
       <h4 class="ui header">Significant Word Order</h4>
       <p>Grids include many variations for adjusting things like vertical or horizontal alignment, text alignment, or default gutter sizes.</p>
       <p>Some multi-word variations, like <a href="#floated"><code>left floated</code></a> or <a href="#text-alignment"><code>right aligned</code></a> are word-order dependent and require you to use adjacent class names.</p>

--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -40,7 +40,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="highlighted example" data-use-content="true" data-class="column">
+    <div class="highlighted example" data-use-content="true" data-class="!two wide, !four wide, !six wide, !eight wide, wide, column">
       <h4 class="ui header">Columns</h4>
       <p>Grids divide horizontal space into indivisible units called "columns". All columns in a grid must specify their width as proportion of the total available row width.</p>
       <p>All grid systems choose an arbitrary column count to allow per row. Fomantic's default theme uses <b>16 columns</b>.</p>
@@ -186,7 +186,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="highlighted example" data-use-content="true" data-class="!eight wide, wide">
+    <div class="highlighted example" data-use-content="true" data-class="!two wide, !four wide, !six wide, !eight wide, !ten wide, !twelve wide, !fourteen wide, !sixteen wide, wide">
       <h4 class="ui header">Column Widths</h4>
       <p>Column widths can be specified using <a href="#column-width"><code>(x) wide</code></a> class names. If a column cannot fit in a row it will automatically flow to the next row</p>
       <div class="ui grid">
@@ -202,7 +202,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="highlighted example" data-use-content="true" data-class="wide" data-since="2.9.2">
+    <div class="highlighted example" data-use-content="true" data-class="left attached, right attached" data-since="2.9.2">
       <h4 class="ui header">Left / Right Attached Column</h4>
       <p>A column can be attached to the left or right without any padding. This is especially useful when working with a <a href="/collections/menu.html#tabular"><code>vertical tabular menu</code></a></p>
       <div class="ui two column grid">
@@ -213,7 +213,7 @@ themes      : ['Default']
 
     <h2 class="ui dividing header">Rows</h2>
 
-    <div class="highlighted example">
+    <div class="highlighted example" data-class="row, !two column, !four column">
       <h4 class="ui header">Grouping</h4>
       <p>Row wrappers allow you to apply variations to a group of columns.</p>
       <div class="ui four column grid">
@@ -242,7 +242,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-class="internally celled">
+    <div class="example" data-class="!internally celled">
       <h4 class="ui header">Special Grids</h4>
       <p>Additionally, some types of grids, like <a href="#divided"><code>divided</code></a> or <a href="#celled"><code>celled</code></a> require row wrappers to apply formatting correctly.</p>
 
@@ -352,7 +352,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-use-content="true" data-class="!left floated right aligned, !right floated left aligned, center aligned, sixteen wide">
+    <div class="example" data-use-content="true" data-class="!left floated, !right aligned, !right floated,  !left aligned, !center aligned, !sixteen wide">
       <h4 class="ui header">Significant Word Order</h4>
       <p>Grids include many variations for adjusting things like vertical or horizontal alignment, text alignment, or default gutter sizes.</p>
       <p>Some multi-word variations, like <a href="#floated"><code>left floated</code></a> or <a href="#text-alignment"><code>right aligned</code></a> are word-order dependent and require you to use adjacent class names.</p>
@@ -415,7 +415,7 @@ themes      : ['Default']
         <div class="column"></div>
       </div>
     </div>
-    <div class="example" data-class="mobile reversed">
+    <div class="example" data-class="!mobile reversed">
       <h4 class="ui header">Reverse Order</h4>
       <p>Fomantic includes special <a href="#reversed"><code>reversed</code></a> variations that allow you to reverse the order of columns or rows by device</p>
       <div class="ui mobile reversed equal width grid">
@@ -540,7 +540,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="!vertically divided">
       <h4 class="ui header">
         Vertically Divided
         <span class="ui black label">Requires Rows</span>
@@ -679,7 +679,7 @@ themes      : ['Default']
     <h2 class="ui dividing header">Variations</h2>
 
 
-    <div class="example" data-use-content="true">
+    <div class="example" data-use-content="true" data-class="!right floated,!left floated,floated">
       <h4 class="ui header">Floated</h4>
       <p>A column can sit flush against the left or right edge of a row</p>
       <div class="ui grid">
@@ -692,7 +692,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-use-content="true" data-class="!four wide,wide">
+    <div class="example" data-use-content="true" data-class="!three wide, !four wide, !nine wide">
       <h4 class="ui header">Column Width</h4>
       <p>A column can vary in width taking up more than a single grid column.</p>
       <div class="ui grid">
@@ -757,7 +757,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-use-content="true">
+    <div class="example" data-use-content="true" data-class="!equal width">
       <h4 class="ui header">
         Equal Width
       </h4>
@@ -1342,7 +1342,7 @@ themes      : ['Default']
         </div>
       </div>
     </div>
-    <div class="example" data-use-content="true" data-class="computer reversed, tablet reversed, mobile reversed, computer vertically reversed, mobile vertically reversed, tablet vertically reversed">
+    <div class="example" data-use-content="true" data-class="!computer reversed, !tablet reversed, !mobile reversed, !computer vertically reversed, !mobile vertically reversed, !tablet vertically reversed">
       <h4 class="ui header">Reversed</h4>
       <p>A grid or row can specify that its columns should reverse order at different device sizes</p>
       <div class="ui ignored info message message">Reversed grids are compatible with <code>divided</code> grids and other complex grid types.</div>
@@ -1454,7 +1454,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-use-content="true" data-class="widescreen only, large screen only, computer only, tablet only, mobile only">
+    <div class="example" data-use-content="true" data-class="!widescreen only, !large screen only, !computer only, !tablet only, !mobile only">
       <h4 class="ui header">Device Visibility</h4>
       <p>A columns or row can appear only for a specific device, or screen sizes</p>
       <div class="ui text message info ignore">

--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -202,8 +202,8 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="highlighted example" data-use-content="true" data-class="wide">
-      <h4 class="ui header">Left / Right Attached Column <span class="ui black label">New in 2.9.2</span></h4>
+    <div class="highlighted example" data-use-content="true" data-class="wide" data-since="2.9.2">
+      <h4 class="ui header">Left / Right Attached Column</h4>
       <p>A column can be attached to the left or right without any padding. This is especially useful when working with a <a href="/collections/menu.html#tabular"><code>vertical tabular menu</code></a></p>
       <div class="ui two column grid">
         <div class="left attached column"></div>
@@ -352,7 +352,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-use-content="true" data-class="left floated right aligned, right floated left aligned, center aligned, sixteen wide">
+    <div class="example" data-use-content="true" data-class="!left floated right aligned, !right floated left aligned, center aligned, sixteen wide">
       <h4 class="ui header">Significant Word Order</h4>
       <p>Grids include many variations for adjusting things like vertical or horizontal alignment, text alignment, or default gutter sizes.</p>
       <p>Some multi-word variations, like <a href="#floated"><code>left floated</code></a> or <a href="#text-alignment"><code>right aligned</code></a> are word-order dependent and require you to use adjacent class names.</p>

--- a/server/documents/collections/menu.html.eco
+++ b/server/documents/collections/menu.html.eco
@@ -880,7 +880,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
       </div>
     </div>
   </div>
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored</h4>
     <p>Additional colors can be specified.</p>
     <div class="ui menu">

--- a/server/documents/collections/menu.html.eco
+++ b/server/documents/collections/menu.html.eco
@@ -1298,9 +1298,9 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   </div>
 
 
-  <div class="example">
+  <div class="example" data-since="2.9.3">
     <h4 class="ui header">Evenly Divided</h4>
-        <p>A menu may divide its items evenly by either using <code>equal width</code> <span class="ui small black label">New in 2.9.3</span> ...</p>
+        <p>A menu may divide its items evenly by either using <code>equal width</code> ...</p>
     <div class="ui equal width menu">
       <a class="item">Buy</a>
       <a class="item">Sell</a>
@@ -1677,8 +1677,8 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Centered Fluid <span class="ui black label">New in 2.9.2</span></h4>
+  <div class="example" data-since="2.9.2">
+    <h4 class="ui header">Centered Fluid</h4>
     <p>A menu can be shown centered and fluid at the same time.</p>
     <div class="ui centered fluid menu">
       <a class="bug popup icon item">
@@ -1693,8 +1693,8 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Wrapping <span class="ui black label">New in 2.9.2</span></h4>
+  <div class="example" data-since="2.9.2">
+    <h4 class="ui header">Wrapping</h4>
     <p>Menu items can automatically wrap on responsive layouts</p>
     <div class="ui inverted wrapped green wrapping menu">
       <a class="active item">One</a>
@@ -1723,8 +1723,8 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Centered Fluid Wrapping <span class="ui black label">New in 2.9.2</span></h4>
+  <div class="example" data-since="2.9.2">
+    <h4 class="ui header">Centered Fluid Wrapping</h4>
     <p>By combining centered, fluid and wrapping you could create a menu similar to <a href="/elements/button.html#wrapping-buttons">Wrapping button groups</a></p>
     <div class="ui inverted wrapped blue centered fluid wrapping menu">
       <a class="active item">One</a>

--- a/server/documents/collections/menu.html.eco
+++ b/server/documents/collections/menu.html.eco
@@ -1523,7 +1523,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
     <p>A vertical menu can also vary in size</p>
     <div class="ui mini vertical menu">
       <a class="active item">
-        <div class="ui teal label">1</div>
+        <div class="ui green label">1</div>
         Inbox
       </a>
       <a class="item">
@@ -1545,7 +1545,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   <div class="another example">
     <div class="ui small vertical menu">
       <a class="active item">
-        <div class="ui small teal label">1</div>
+        <div class="ui small green label">1</div>
         Inbox
       </a>
       <a class="item">
@@ -1567,7 +1567,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   <div class="another example">
     <div class="ui large vertical menu">
       <a class="active item">
-        <div class="ui small teal label">1</div>
+        <div class="ui small green label">1</div>
         Inbox
       </a>
       <a class="item">
@@ -1589,7 +1589,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   <div class="another example">
     <div class="ui massive vertical menu">
       <a class="active item">
-        <div class="ui small teal label">1</div>
+        <div class="ui small green label">1</div>
         Inbox
       </a>
       <a class="item">

--- a/server/documents/collections/menu.html.eco
+++ b/server/documents/collections/menu.html.eco
@@ -742,7 +742,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
 
   <h2 class="ui dividing header">Variations</h2>
 
-  <div class="fixed example">
+  <div class="fixed example" data-class="!top fixed, !bottom fixed, !left fixed, !right fixed">
     <h4 class="ui header">Fixed</h4>
     <p>A menu can be fixed to a side of its context</p>
     <div class="ui ignored info message">These examples use a an <code>iframe</code>, to prevent content from sticking to the browser viewport.</div>
@@ -1298,7 +1298,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   </div>
 
 
-  <div class="example" data-since="2.9.3">
+  <div class="example" data-since="2.9.3" data-class="!equal width, three item">
     <h4 class="ui header">Evenly Divided</h4>
         <p>A menu may divide its items evenly by either using <code>equal width</code> ...</p>
     <div class="ui equal width menu">
@@ -1342,7 +1342,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   </div>
 
 
-  <div class="example">
+  <div class="example" data-class="!top attached, !bottom attached">
     <h4 class="ui header">Attached</h4>
     <p>A menu may be attached to other content segments</p>
     <div class="ui top attached tabular menu">

--- a/server/documents/collections/message.html.eco
+++ b/server/documents/collections/message.html.eco
@@ -49,7 +49,7 @@ themes      : ['Default', 'GitHub', 'Gmail']
   <div class="example">
     <h4 class="ui header">
       Icon Message
-      <span class="ui teal label">Flexbox</span>
+      <span class="ui orange label">Flexbox</span>
     </h4>
     <p>A message can contain an icon.</p>
     <div class="ui icon message">

--- a/server/documents/collections/message.html.eco
+++ b/server/documents/collections/message.html.eco
@@ -282,7 +282,7 @@ themes      : ['Default', 'GitHub', 'Gmail']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored</h4>
     <p>A message can be formatted to be different colors</p>
     <div class="ui red message">Red</div>

--- a/server/documents/collections/message.html.eco
+++ b/server/documents/collections/message.html.eco
@@ -122,8 +122,8 @@ themes      : ['Default', 'GitHub', 'Gmail']
 
   <h2 class="ui dividing header">Variations</h2>
 
-  <div class="example">
-    <h4 class="ui header">Center Aligned <span class="ui black label">New in 2.8.8</span></h4>
+  <div class="example" data-since="2.8.8">
+    <h4 class="ui header">Center Aligned</h4>
     <p>A message can be displayed center aligned</p>
     <div class="ui center aligned message">
       <div class="content">
@@ -135,8 +135,8 @@ themes      : ['Default', 'GitHub', 'Gmail']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Right Aligned <span class="ui black label">New in 2.8.8</span></h4>
+  <div class="example" data-since="2.8.8">
+    <h4 class="ui header">Right Aligned</h4>
     <p>A message can be displayed right aligned</p>
     <div class="ui right aligned message">
       <div class="content">

--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -580,7 +580,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example" data-since="2.7" data-class="colors">
+  <div class="example" data-since="2.7" data-class="colors" data-use-content="true">
     <h4 class="ui header">Colored Cells</h4>
     <p>A cell can be styled by the central color palette colors</p>
     <table class="ui celled table">
@@ -678,7 +678,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
 
   <h2 class="ui dividing header">Variations</h2>
 
-  <div class="example">
+  <div class="example" data-class="!single line">
     <h4 class="ui header">Single Line</h4>
     <p>A table can specify that its cell contents should remain on a single line, and not wrap.</p>
     <table class="ui single line table">
@@ -773,7 +773,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
+  <div class="example" class="!tablet stackable, unstackable">
     <h4 class="ui header">Stacking</h4>
     <p>A table can specify how it stacks table content responsively</p>
 
@@ -965,7 +965,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!top aligned, !middle aligned, !bottom aligned">
     <h4 class="ui header">Vertical Alignment</h4>
     <p>A table header, row, or cell can adjust its vertical alignment</p>
     <table class="ui striped table">
@@ -999,7 +999,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!left aligned, !right aligned, !center aligned" data-use-content="true">
     <h4 class="ui header">Text Alignment</h4>
     <p>A table header, row, or cell can adjust its text alignment</p>
     <table class="ui striped table">
@@ -1131,7 +1131,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!very basic, basic">
     <h4 class="ui header">Basic</h4>
     <p>A table can reduce its complexity to increase readability.</p>
     <table class="ui basic table">
@@ -1271,7 +1271,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="ten wide, six wide" data-use-content="true">
     <h4 class="ui header">Column Width</h4>
     <p>A table can specify the width of individual columns independently.</p>
     <div class="ui ignored info message">Tables use a 16 column grid similar to <a href="/collections/grid.html">ui grid</a></div>
@@ -1917,7 +1917,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
       </tfoot>
     </table>
   </div>
-  <div class="example">
+  <div class="example" data-class="!very padded, padded">
     <h4 class="ui header">Padded</h4>
     <p>A table may sometimes need to be more padded for legibility</p>
     <table class="ui padded table">
@@ -1965,7 +1965,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
       </tbody>
     </table>
   </div>
-  <div class="example">
+  <div class="example" data-class="!very compact, compact">
     <h4 class="ui header">Compact</h4>
     <p>A table may sometimes need to be more compact to make more rows visible at a time</p>
     <table class="ui compact table">

--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -580,8 +580,8 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Colored Cells<div class="ui black label">New in 2.7</div></h4>
+  <div class="example" data-since="2.7">
+    <h4 class="ui header">Colored Cells</h4>
     <p>A cell can be styled by the central color palette colors</p>
     <table class="ui celled table">
       <thead>
@@ -616,8 +616,8 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Marked<div class="ui black label">New in 2.8</div></h4>
+  <div class="example" data-since="2.8.0" data-class="marked, !blue marked, !green marked, !orange marked, !red marked, !blue marked, !purple marked" data-use-content="true">
+    <h4 class="ui header">Marked</h4>
     <p>A cell or row can be marked by a colored left or right border</p>
     <div class="ui ignored warning message">
       <p>Since 2.9.0 you have to follow the class order: First color name, then <code>marked</code>. This is to support <a href="#colored-and-marked">colored and marked</a> cells</p>
@@ -655,8 +655,8 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Colored and Marked<div class="ui black label">New in 2.9</div></h4>
+  <div class="example" data-class="colored, marked, !red colored, !blue marked, !green colored, !yellow colored, !red marked, !purple marked" data-use-content="true" data-since="2.9">
+    <h4 class="ui header">Colored and Marked</h4>
     <p>If you need colored cells which are also marked at the same time in a different color, you have to follow a specific class order and add the <code>colored</code> class to the cell color.<br>For example <code>red colored right blue marked</code> .</p>
     <table class="ui celled table">
       <thead>
@@ -2149,8 +2149,8 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
       </tfoot>
     </table>
   </div>
-  <div class="example">
-    <h4 class="ui header">Scrolling<div class="ui black label">New in 2.9</div></h4>
+  <div class="example" data-since="2.9">
+    <h4 class="ui header">Scrolling</h4>
     <p>A table body can scroll vertically.</p>
     <div class="ui ignored warning message">
         Some table variants like <a href="#column-width">column width</a> or <a href="#single-line">single line</a> do not work with a scrolling table.
@@ -2377,8 +2377,8 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </tfoot>
     </table>
   </div>
-  <div class="example">
-    <h4 class="ui header">Stuck<div class="ui black label">New in 2.9</div></h4>
+  <div class="example" data-since="2.9">
+    <h4 class="ui header">Stuck</h4>
     <p>A table can scroll horizontally having its <code>head</code>, <code>foot</code>, <code>first</code> or <code>last</code> column keep staying stuck.</p>
     <p>You can freely stick any combination like <code>head first stuck</code>, <code>foot first last stuck</code>, <code>head foot first stuck</code>, <code>first last stuck</code>, etc.</p>
     <div class="ui ignored info message">

--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -580,7 +580,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example" data-since="2.7">
+  <div class="example" data-since="2.7" data-class="colors">
     <h4 class="ui header">Colored Cells</h4>
     <p>A cell can be styled by the central color palette colors</p>
     <table class="ui celled table">
@@ -632,7 +632,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
       </thead>
       <tbody>
         <tr>
-          <td class="right blue marked blue">No Name Specified</td>
+          <td class="right blue marked">No Name Specified</td>
           <td class="left red marked">Unknown</td>
           <td>None</td>
         </tr>
@@ -1337,7 +1337,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored</h4>
     <p>A table can be given a color to distinguish it from other tables.</p>
     <table class="ui red table">
@@ -1352,7 +1352,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
           <td>0g</td>
         </tr>
         <tr>
-          <td>Orange</td>
+          <td>Tomatoes</td>
           <td>310</td>
           <td>0g</td>
         </tr>

--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -437,7 +437,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
   </div>
 
   <h3 class="ui header">Cells</h3>
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Error</h4>
     <p>A cell or row may call attention to an error or a negative value</p>
     <table class="ui celled table">
@@ -473,7 +473,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Warning</h4>
     <p>A cell or row may warn a user</p>
     <table class="ui celled table">
@@ -509,7 +509,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Active</h4>
     <p>A cell or row can be active or selected by a user</p>
     <table class="ui celled table">
@@ -544,7 +544,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
       </tbody>
     </table>
   </div>
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Disabled</h4>
     <p>A cell can be disabled</p>
     <table class="ui celled table">

--- a/server/documents/elements/button.html.eco
+++ b/server/documents/elements/button.html.eco
@@ -138,7 +138,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
     </button>
   </div>
 
-  <div class="example" data-class="labeled icon, right labeled icon">
+  <div class="example" data-class="labeled icon, !right labeled, icon">
     <h4 class="ui header">Labeled Icon</h4>
     <p>A button can use an icon as a label</p>
     <button class="ui labeled icon button">
@@ -427,7 +427,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
   </div>
 
 
-  <div class="spaced example">
+  <div class="spaced example" data-class="colors">
     <h4 class="ui header">Colored</h4>
     <p>A button can have different colors</p>
     <button class="ui red button">Red</button>
@@ -508,7 +508,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
     </button>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!top attached, !bottom attached, attached">
     <h4 class="ui header">Vertically Attached</h4>
     <p>A button can be attached to the top or bottom of other content</p>
     <div class="ui top attached button" tabindex="0">Top</div>
@@ -532,7 +532,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!left attached, !right attached">
     <h4 class="ui header">Horizontally Attached</h4>
     <p>A button can be attached to the left or right of other content</p>
     <button class="ui left attached button">Left</button>
@@ -598,7 +598,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
       </button>
     </div>
   </div>
-  <div class="example" data-class="labeled icon, ui button, ui buttons, right labeled icon">
+  <div class="example" data-class="labeled icon, ui button, ui buttons, !right labeled, icon">
     <h4 class="ui header">Mixed Group</h4>
     <p>Groups can be formatted to use multiple button types together</p>
     <div class="ui buttons">
@@ -637,7 +637,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
   </div>
 
 
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored Buttons</h4>
     <p>Groups can have a shared color</p>
     <div class="blue ui buttons">

--- a/server/documents/elements/button.html.eco
+++ b/server/documents/elements/button.html.eco
@@ -419,7 +419,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
     </button>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!right floated,!left floated,floated">
     <h4 class="ui header">Floated</h4>
     <p>A button can be aligned to the left or right of its container</p>
     <button class="ui right floated button">Right Floated</button>

--- a/server/documents/elements/button.html.eco
+++ b/server/documents/elements/button.html.eco
@@ -83,7 +83,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
     </div>
   </div>
 
-  <div class="example" data-class="labeled, left labeled">
+  <div class="example" data-class="labeled, !left labeled">
     <h4 class="ui header">Labeled</h4>
     <p>A button can appear alongside a <a href="/elements/label.html">label</a></p>
     <div class="ui labeled button" tabindex="0">
@@ -695,8 +695,8 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Wrapping Buttons <span class="ui black label">New in 2.9.0</span></h4>
+  <div class="example" data-since="2.9.0">
+    <h4 class="ui header">Wrapping Buttons</h4>
     <p>Groups buttons can automatically wrap sharing the overall available width</p>
     <div class="ui wrapped wrapping buttons">
       <button class="ui button">One</button>
@@ -725,8 +725,8 @@ themes      : ['Default', 'Classic', 'Basic', 'Bootstrap3', 'Twitter', 'Raised',
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Spaced Buttons <span class="ui black label">New in 2.9.0</span></h4>
+  <div class="example" data-since="2.9.0">
+    <h4 class="ui header">Spaced Buttons</h4>
     <p>Buttons inside groups can automatically get a margin so they dont appear attached together, especially when used together with <a href="#wrapping-buttons">wrapping</a> on responsive layouts</p>
     <div class="ui wrapping spaced buttons">
       <button class="ui button">One</button>

--- a/server/documents/elements/container.html.eco
+++ b/server/documents/elements/container.html.eco
@@ -291,8 +291,8 @@ themes      : ['Default']
       Curabitur ullamcorper ultricies nisi.</p>
     </div>
 
-  <div class="example">
-    <h4 class="ui header">Scrolling<div class="ui black label">New in 2.9</div></h4>
+  <div class="example" data-since="2.9">
+    <h4 class="ui header">Scrolling</h4>
     <p>A scrolling container has a predefined height to allow its content to be scrollable</p>
     <div class="ui scrolling container">
       <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>

--- a/server/documents/elements/container.html.eco
+++ b/server/documents/elements/container.html.eco
@@ -220,7 +220,7 @@ themes      : ['Default']
 
     <h2 class="ui dividing header">Variations</h2>
 
-    <div class="no example">
+    <div class="no example" data-class="!left aligned, !center aligned, !right aligned">
       <h4 class="ui header">Text Alignment</h4>
       <p>A container can specify its text alignment</p>
 
@@ -291,7 +291,7 @@ themes      : ['Default']
       Curabitur ullamcorper ultricies nisi.</p>
     </div>
 
-  <div class="example" data-since="2.9">
+  <div class="example" data-since="2.9" data-class="!very short, !very long">
     <h4 class="ui header">Scrolling</h4>
     <p>A scrolling container has a predefined height to allow its content to be scrollable</p>
     <div class="ui scrolling container">

--- a/server/documents/elements/divider.html.eco
+++ b/server/documents/elements/divider.html.eco
@@ -110,7 +110,7 @@ themes      : ['default']
       <div class="ui horizontal divider">
         Or
       </div>
-      <div class="ui teal labeled icon button">
+      <div class="ui green labeled icon button">
         Create New Order
         <i class="add icon"></i>
       </div>

--- a/server/documents/elements/divider.html.eco
+++ b/server/documents/elements/divider.html.eco
@@ -148,7 +148,7 @@ themes      : ['default']
     </table>
   </div>
 
-  <div class="example" data-class="left aligned,right aligned">
+  <div class="example" data-class="!left aligned,!right aligned">
     <h4 class="ui header">Horizontal Alignment</h4>
     <p>A horizontal divider can be aligned</p>
 

--- a/server/documents/elements/header.html.eco
+++ b/server/documents/elements/header.html.eco
@@ -256,7 +256,7 @@ themes      : ['Default', 'Classic', 'Bookish', 'Chubby', 'Material']
     </h3>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!left floated,!right floated" data-use-content="true">
     <h4 class="ui header">Floating</h4>
     <p>A header can sit to the left or right of other content</p>
     <div class="ui clearing segment">
@@ -287,7 +287,7 @@ themes      : ['Default', 'Classic', 'Bookish', 'Chubby', 'Material']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored</h4>
     <p>A header can be formatted with different colors</p>
     <h4 class="ui primary header">Primary</h4>

--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -7268,7 +7268,7 @@ themes      : ['Default']
       <i class="bordered colored green users icon"></i>
       <i class="bordered colored blue users icon"></i>
     </div>
-    <div class="example">
+    <div class="example" data-class="colors">
       <h4 class="ui header">Colored</h4>
       <p>An icon can be formatted with different colors</p>
       <i class="primary users icon"></i>
@@ -7326,7 +7326,7 @@ themes      : ['Default']
         <i class="black user icon"></i>
       </i>
     </div>
-    <div class="example" data-class="corner">
+    <div class="example" data-class="corner, !top left, !top right, !bottom left, !bottom right">
       <h4 class="ui header">Corner Icon</h4>
       <p>A group of icons can display a smaller corner icon</p>
       <i class="huge icons">

--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -7243,8 +7243,8 @@ themes      : ['Default']
       <i class="circular inverted users icon"></i>
       <i class="circular inverted teal users icon"></i>
     </div>
-    <div class="example">
-      <h4 class="ui header">Circular Colored <span class="ui black label">New in 2.8.8</span></h4>
+    <div class="example" data-since="2.8.8">
+      <h4 class="ui header">Circular Colored</h4>
       <p>The circular color can appear in the same color as the icon itself</p>
       <i class="circular colored red users icon"></i>
       <i class="circular colored green users icon"></i>
@@ -7261,8 +7261,8 @@ themes      : ['Default']
       <i class="bordered inverted black users icon"></i>
       <i class="bordered inverted teal users icon"></i>
     </div>
-    <div class="example">
-      <h4 class="ui header">Bordered Colored <span class="ui black label">New in 2.8.8</span></h4>
+    <div class="example" data-since="2.8.8">
+      <h4 class="ui header">Bordered Colored</h4>
       <p>The bordered color can appear in the same color as the icon itself</p>
       <i class="bordered colored red users icon"></i>
       <i class="bordered colored green users icon"></i>

--- a/server/documents/elements/image.html.eco
+++ b/server/documents/elements/image.html.eco
@@ -126,7 +126,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!left spaced, !right spaced, spaced">
     <h4 class="ui header">Spaced</h4>
     <p>An image can specify that it needs an additional spacing to separate it from nearby content</p>
 
@@ -141,7 +141,7 @@ themes      : ['Default']
       <p>Eu quo homero blandit intellegebat. Incorrupte consequuntur mei id. Mei ut facer dolores adolescens, no illum aperiri quo, usu odio brute at. Qui te porro electram, ea dico facete utroque quo. Populo quodsi te eam, wisi everti eos ex, eum elitr altera utamur at. Quodsi convenire mnesarchum eu per, quas minimum postulant per id.<img class="ui mini left spaced image" src="/images/wireframe/image.png"></p>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="left floated, right floated">
     <h4 class="ui header">Floated</h4>
     <p>An image can sit to the left or right of other content</p>
     <div class="ui segment">

--- a/server/documents/elements/input.html.eco
+++ b/server/documents/elements/input.html.eco
@@ -180,7 +180,7 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example" data-class="left labeled, left corner labeled, right corner labeled, right labeled, labeled">
+  <div class="example" data-class="!left icon, left labeled, !left corner labeled, !corner labeled, right corner labeled, !right labeled, labeled">
     <h4 class="ui header">Labeled</h4>
     <p>An input can be formatted with a label</p>
     <div class="ui labeled input">
@@ -267,7 +267,7 @@ themes      : ['Default', 'GitHub']
         <div class="ui basic label">Persons</div>
       </div>
   </div>
-  <div class="example" data-class="left action, right action, action">
+  <div class="example" data-class="!left action, right action, action">
     <h4 class="ui header">Action</h4>
     <p>An input can be formatted to alert the user to an action they may perform</p>
     <div class="ui action input">

--- a/server/documents/elements/input.html.eco
+++ b/server/documents/elements/input.html.eco
@@ -31,9 +31,9 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-since="2.9.0">
     <h4 class="ui header">
-      File Input <div class="ui black label">New in 2.9.0</div>
+      File Input
     </h4>
     <p>A file input</p>
     <div class="ui file input">
@@ -43,9 +43,9 @@ themes      : ['Default', 'GitHub']
     If you want the trigger button having a custom text or an icon, you should use a <a href="#file-action">File Action Input</a>
     </div>
   </div>
-  <div class="example">
+  <div class="example" data-since="2.9.0">
     <h4 class="ui header">
-      Invisible File Input <div class="ui black label">New in 2.9.0</div>
+      Invisible File Input
     </h4>
     <p>A file input can be made invisible so you are able to design another element to trigger the file dialog.</p>
     <p>To accomplish this, you have to use a corresponding <code>&lt;label&gt;</code> element. This can be styled as desired, most probably as a button element</p>
@@ -327,8 +327,8 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">File Action<div class="ui black label">New in 2.9.0</div></h4>
+  <div class="example" data-since="2.9.0">
+    <h4 class="ui header">File Action</h4>
     <p>A File action input allows custom content inside the file trigger button. File action input buttons have to be made out of a label element.</p>
     <div class="ui ignored warning message">
         Although <code>left action</code> also works with file action inputs, in order to support button highlighting on key tabbing, the action button needs to be placed after the file input so it appears to the right.
@@ -437,10 +437,9 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-since="2.7">
     <h4 class="ui header">
         Textarea
-        <div class="ui black label">New in 2.7</div>
     </h4>
     <p>Using the input class you can also use some features on <code>textarea</code> as well</p>
     <div class="ui form">

--- a/server/documents/elements/input.html.eco
+++ b/server/documents/elements/input.html.eco
@@ -277,7 +277,7 @@ themes      : ['Default', 'GitHub']
   </div>
   <div class="another example">
     <div class="ui left action input">
-      <button class="ui teal labeled icon button">
+      <button class="ui green labeled icon button">
         <i class="cart icon"></i>
         Checkout
       </button>

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -371,7 +371,7 @@ themes      : ['Default', 'GitHub']
       </a>
       <a class="item">
         <i class="icon users"></i> Friends
-        <div class="floating ui teal label">22</div>
+        <div class="floating ui blue label">22</div>
       </a>
     </div>
     <br><br>
@@ -382,11 +382,11 @@ themes      : ['Default', 'GitHub']
       </a>
       <a class="item">
         <i class="icon users"></i> Friends
-        <div class="floating ui teal label">22 Friends</div>
+        <div class="floating ui blue label">22 Friends</div>
       </a>
     </div>
     <br><br>
-    <div class="ui black bottom pointing label">New in 2.7.2</div>
+    <div class="ui teal bottom pointing label">New in 2.7.2</div>
     <br>
     <div class="ui compact menu">
       <a class="item">
@@ -395,7 +395,7 @@ themes      : ['Default', 'GitHub']
       </a>
       <a class="item">
         <i class="icon users"></i> Friends
-        <div class="bottom floating ui teal label">22</div>
+        <div class="bottom floating ui blue label">22</div>
       </a>
     </div>
     <br><br>
@@ -406,7 +406,7 @@ themes      : ['Default', 'GitHub']
       </a>
       <a class="item">
         <i class="icon users"></i> Friends
-        <div class="bottom floating ui teal label">22 Friends</div>
+        <div class="bottom floating ui blue label">22 Friends</div>
       </a>
     </div>
   </div>
@@ -421,7 +421,7 @@ themes      : ['Default', 'GitHub']
       </a>
       <a class="item">
         <i class="icon users"></i> Friends
-        <div class="left floating ui teal label">22</div>
+        <div class="left floating ui blue label">22</div>
       </a>
     </div>
     <br><br>
@@ -432,7 +432,7 @@ themes      : ['Default', 'GitHub']
       </a>
       <a class="item">
         <i class="icon users"></i> Friends
-        <div class="left floating ui teal label">22 Friends</div>
+        <div class="left floating ui blue label">22 Friends</div>
       </a>
     </div>
   </div>
@@ -447,7 +447,7 @@ themes      : ['Default', 'GitHub']
       </a>
       <a class="item">
         <i class="icon users"></i> Friends of the Fomantic-UI Community
-        <div class="right aligned floating ui teal label">22 Friends online</div>
+        <div class="right aligned floating ui blue label">22 Friends online</div>
       </a>
     </div>
   </div>

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -260,8 +260,8 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example" data-class="bottom ribbon, center ribbon, ribbon">
-    <h4 class="ui header">Bottom and Center Ribbon <div class="ui black label">New in 2.9.3</div></h4>
+  <div class="example" data-class="bottom ribbon, center ribbon, ribbon" data-since="2.9.3">
+    <h4 class="ui header">Bottom and Center Ribbon</h4>
     <p>A ribbon label can appear vertically centered or positioned to the bottom.</p>
     <div class="ui raised horizontal segments">
       <div class="ui segment">
@@ -410,9 +410,8 @@ themes      : ['Default', 'GitHub']
       </a>
     </div>
   </div>
-  <div class="example">
+  <div class="example" data-since="2.7.2">
     <h4 class="ui header">Floating left
-        <div class="ui black label">New in 2.7.2</div>
     </h4>
     <p>Floating Labels can be positioned to the left also</p>
     <div class="ui compact menu">
@@ -437,9 +436,8 @@ themes      : ['Default', 'GitHub']
       </a>
     </div>
   </div>
-  <div class="example">
+  <div class="example" data-since="2.7.2">
     <h4 class="ui header">Floating aligned
-      <div class="ui black label">New in 2.7.2</div>
     </h4>
     <p>Floating Labels containing large text can be aligned to the left or right</p>
     <div class="ui compact menu">
@@ -454,8 +452,8 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Inverted <span class="ui black label">New in 2.7</span></h4>
+  <div class="example" data-since="2.7">
+    <h4 class="ui header">Inverted</h4>
     <p>All Variants of Label can be inverted</p>
     <div class="ui inverted segment" >
         <a class="ui primary inverted label">Primary</a>
@@ -650,8 +648,8 @@ themes      : ['Default', 'GitHub']
     <p>A label can take the width of its container</p>
     <div class="ui fluid label">Fits container</div>
   </div>
-  <div class="example">
-    <h4 class="ui header">Centered <span class="ui black label">New in 2.9.1</span></h4>
+  <div class="example" data-since="2.9.1">
+    <h4 class="ui header">Centered</h4>
     <p>Text can be shown centered</p>
     <div class="ui fluid centered label">Fits container</div>
   </div>
@@ -688,10 +686,8 @@ themes      : ['Default', 'GitHub']
     <a class="ui black empty circular label"></a>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Basic
-      <div class="ui black label">New in 2.1</div>
-    </h4>
+  <div class="example" data-since="2.1">
+    <h4 class="ui header">Basic</h4>
     <p>A label can reduce its complexity</p>
     <a class="ui basic label">Basic</a>
     <a class="ui pointing basic label">Pointing</a>
@@ -723,10 +719,8 @@ themes      : ['Default', 'GitHub']
     <a class="ui black label">Black</a>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Basic Tag Labels
-        <div class="ui black label">New in 2.7</div>
-    </h4>
+  <div class="example" data-since="2.7">
+    <h4 class="ui header">Basic Tag Labels</h4>
     <p></p>
     <a class="ui basic tag label">Standard Tag</a>
     <a class="ui primary basic tag label">Primary</a>
@@ -818,10 +812,8 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Basic Group
-        <div class="ui black label">New in 2.7</div>
-    </h4>
+  <div class="example" data-since="2.7">
+    <h4 class="ui header">Basic Group</h4>
     <p>Labels can share their style together</p>
     <div class="ui basic labels">
         <a class="ui label">

--- a/server/documents/elements/label.html.eco
+++ b/server/documents/elements/label.html.eco
@@ -79,7 +79,7 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example" data-class="pointing above, pointing below, left pointing, right pointing">
+  <div class="example" data-class="!pointing above, !pointing below, !left pointing, !right pointing">
     <h4 class="ui header">Pointing</h4>
     <p>A label can point to content next to it</p>
     <form class="ui fluid form">
@@ -176,7 +176,7 @@ themes      : ['Default', 'GitHub']
     <a class="ui teal tag label">Featured</a>
   </div>
 
-  <div class="example" data-class="left ribbon, right ribbon, ribbon">
+  <div class="example" data-class="left ribbon, !right ribbon, ribbon">
     <h4 class="ui header">Ribbon</h4>
     <p>A label can appear as a ribbon attaching itself to an element.</p>
     <div class="ui two column grid">
@@ -518,7 +518,7 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example" data-use-content="true" data-class="icon">
+  <div class="example" data-use-content="true" data-class="icon, !left icon">
     <h4 class="ui header">Icon</h4>
     <p>A label can include an icon</p>
     <div class="ui label">
@@ -699,7 +699,7 @@ themes      : ['Default', 'GitHub']
     </a>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored</h4>
     <p>A label can have different colors</p>
     <a class="ui primary label">Primary</a>
@@ -789,7 +789,7 @@ themes      : ['Default', 'GitHub']
       </div>
     </div>
   </div>
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored Group</h4>
     <p>Labels can share colors together</p>
     <div class="ui blue labels">

--- a/server/documents/elements/list.html.eco
+++ b/server/documents/elements/list.html.eco
@@ -602,7 +602,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!very relaxed" data-use-content="true">
     <h4 class="ui header">Relaxed</h4>
     <p>A list can relax its padding to provide more negative space</p>
 
@@ -933,7 +933,7 @@ themes      : ['Default']
   <h2 class="ui dividing header">Content Variations</h2>
 
 
-  <div class="example" data-use-content="true">
+  <div class="example" data-use-content="true" data-class="!top aligned, !middle aligned, !bottom aligned">
     <h4 class="ui header">Vertically Aligned</h4>
     <p>An element inside a list can be vertically aligned</p>
     <div class="ui horizontal list">

--- a/server/documents/elements/list.html.eco
+++ b/server/documents/elements/list.html.eco
@@ -959,7 +959,7 @@ themes      : ['Default']
   </div>
 
 
-  <div class="example" data-use-content="true">
+  <div class="example" data-class="!right floated,!left floated,floated" data-use-content="true">
     <h4 class="ui header">Floated</h4>
     <p>An list, or an element inside a list can be floated left or right</p>
     <div class="ui middle aligned divided list">

--- a/server/documents/elements/loader.html.eco
+++ b/server/documents/elements/loader.html.eco
@@ -235,7 +235,7 @@ themes      : ['Default', 'Duo', 'Pulsar']
     </div>
   </div>
 
-  <div class="example" data-since="2.7.0>
+  <div class="example" data-since="2.7.0">
     <h4 class="ui header">Styles</h4>
     <p>Loaders can also appear in <code>double</code> or <code>elastic</code> animation style. Can be combined with any color or speed.</p>
     <div class="ui segment">

--- a/server/documents/elements/loader.html.eco
+++ b/server/documents/elements/loader.html.eco
@@ -235,8 +235,8 @@ themes      : ['Default', 'Duo', 'Pulsar']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Styles<div class="ui black label">New in 2.7.0</div></h4>
+  <div class="example" data-since="2.7.0>
+    <h4 class="ui header">Styles</h4>
     <p>Loaders can also appear in <code>double</code> or <code>elastic</code> animation style. Can be combined with any color or speed.</p>
     <div class="ui segment">
         <div class="ui active slow green double loader"></div>

--- a/server/documents/elements/placeholder.html.eco
+++ b/server/documents/elements/placeholder.html.eco
@@ -21,10 +21,9 @@ themes      : ['Default']
 
   <h2 class="ui dividing header">Types</h2>
 
-  <div class="example" data-class="image header, paragraph, line, content, loader, image">
+  <div class="example" data-class="image header, paragraph, line, content, loader, image" data-since="2.4.0">
     <h4 class="ui header">
       Placeholder
-      <div class="ui teal horizontal label">New in 2.4.0</div>
     </h4>
     <p>A placeholder is used to reserve space for content that soon will appear in a layout.</p>
     <div class="ui ignored info message">

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -616,7 +616,7 @@ themes      : ['default', 'GitHub']
     </div>
   </div>
 
-  <div class="clearing example">
+  <div class="clearing example" data-class="!right floated,!left floated,floated">
     <h4 class="ui header">Floated</h4>
     <p>A segment can appear to the left or right of other content</p>
     <div class="ui right floated segment">

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -485,7 +485,7 @@ themes      : ['default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-since="2.7.5">
     <h4 class="ui header">Fitted</h4>
     <p>A segment can remove its padding, vertically or horizontally</p>
     <div class="ui fitted segment">

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -606,7 +606,7 @@ themes      : ['default', 'GitHub']
   </div>
 
 
-  <div class="example" data-since="2.0 data-class="!left floated, !right floated">
+  <div class="example" data-since="2.0" data-class="!left floated, !right floated">
     <h4 class="ui header">
       Clearing
     </h4>

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -26,10 +26,9 @@ themes      : ['default', 'GitHub']
       <img class="ui wireframe image" src="/images/wireframe/short-paragraph.png">
     </div>
   </div>
-  <div class="example">
+  <div class="example" data-since="2.4.0">
     <h4 class="ui header">
       Placeholder Segment
-      <div class="ui teal horizontal label">New in 2.4.0</div>
     </h4>
     <p>A segment can be used to reserve space for conditionally displayed content.</p>
     <div class="ui placeholder segment">
@@ -283,9 +282,8 @@ themes      : ['default', 'GitHub']
       </div>
     </div>
   </div>
-  <div class="example">
+  <div class="example" data-since="2.8.8">
     <h4 class="ui header">Horizontal equal width Segments
-        <div class="ui black label">New in 2.8.8</div>
     </h4>
     <p>A horizontal segment group can automatically divide segments to be equal width</p>
     <div class="ui horizontal equal width segments">
@@ -300,10 +298,8 @@ themes      : ['default', 'GitHub']
         </div>
       </div>
   </div>
-  <div class="example">
-    <h4 class="ui header">Horizontal wrapping Segments
-    <div class="ui black label">New in 2.9.3</div>
-    </h4>
+  <div class="example" data-since="2.9.3">
+    <h4 class="ui header">Horizontal wrapping Segments</h4>
     <div class="ui ignored warning message">
     There also exists a <code>horizontal stackable segments</code> alias but that alias is deprecated by 2.9.3 and will be removed in 2.10.0
     </div>
@@ -400,8 +396,8 @@ themes      : ['default', 'GitHub']
       <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
     </div>
   </div>
-  <div class="another example">
-    <p>The loader inherits the color of the segment, if you want to prevent this, add the <code>usual</code> class, so the loader color stays default, while the segment still gets its color<div class="ui black label">New in 2.7.0</div></p>
+  <div class="another example" data-since="2.7.0">
+    <p>The loader inherits the color of the segment, if you want to prevent this, add the <code>usual</code> class, so the loader color stays default, while the segment still gets its color</p>
     <div class="ui ignored info message"><code>elastic</code> as loading style is currently not supported  because segment uses the <code>:before</code> pseudoclass to dimm the background.</div>
     <div class="ui brown double loading segment">
         <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
@@ -463,8 +459,8 @@ themes      : ['default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
-      <h4 class="ui header">Seamless attached <span class="ui black label">New in 2.9.2</span></h4>
+  <div class="example" data-since="2.9.2">
+      <h4 class="ui header">Seamless attached</h4>
       <p>A segment can be seamless attached removing the related sides border. This is especially useful when working with a <a href="/collections/menu.html#tabular"><code>vertical tabular menu</code></a></p>
       <div class="ui horizontal segments">
           <div class="ui seamless left attached right aligned segment">
@@ -654,8 +650,8 @@ themes      : ['default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Scrolling<div class="ui black label">New in 2.9</div></h4>
+  <div class="example" data-since="2.9">
+    <h4 class="ui header">Scrolling</h4>
     <p>A scrolling segment has a predefined height to allow its content to be scrollable</p>
     <div class="ui scrolling segment">
       <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -606,10 +606,9 @@ themes      : ['default', 'GitHub']
   </div>
 
 
-  <div class="example">
+  <div class="example" data-since="2.0>
     <h4 class="ui header">
       Clearing
-      <span class="ui teal label">New</span>
     </h4>
     <p>A segment can clear floated content</p>
     <div class="ui clearing segment">

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -282,7 +282,7 @@ themes      : ['default', 'GitHub']
       </div>
     </div>
   </div>
-  <div class="example" data-since="2.8.8">
+  <div class="example" data-since="2.8.8" data-class="!equal width">
     <h4 class="ui header">Horizontal equal width Segments
     </h4>
     <p>A horizontal segment group can automatically divide segments to be equal width</p>
@@ -417,7 +417,7 @@ themes      : ['default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!top attached, !bottom attached">
     <h4 class="ui header">Attached</h4>
     <p>A segment can be attached to other content on a page</p>
 
@@ -472,7 +472,7 @@ themes      : ['default', 'GitHub']
       </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!very padded">
     <h4 class="ui header">Padded</h4>
     <p>A segment can increase its padding</p>
     <div class="ui padded segment">
@@ -517,7 +517,7 @@ themes      : ['default', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored</h4>
     <p>A segment can be colored</p>
     <div class="ui red segment">Red</div>
@@ -606,7 +606,7 @@ themes      : ['default', 'GitHub']
   </div>
 
 
-  <div class="example" data-since="2.0>
+  <div class="example" data-since="2.0 data-class="!left floated, !right floated">
     <h4 class="ui header">
       Clearing
     </h4>
@@ -627,7 +627,7 @@ themes      : ['default', 'GitHub']
     </div>
   </div>
 
-  <div class="clearing example">
+  <div class="clearing example" data-class="!left aligned, !right aligned, !center aligned">
     <h4 class="ui header">Text Alignment</h4>
     <p>A segment can have its text aligned to a side</p>
     <div class="ui right aligned segment">
@@ -649,7 +649,7 @@ themes      : ['default', 'GitHub']
     </div>
   </div>
 
-  <div class="example" data-since="2.9">
+  <div class="example" data-since="2.9" data-class="!very short, !very long, short, long">
     <h4 class="ui header">Scrolling</h4>
     <p>A scrolling segment has a predefined height to allow its content to be scrollable</p>
     <div class="ui scrolling segment">

--- a/server/documents/elements/step.html.eco
+++ b/server/documents/elements/step.html.eco
@@ -262,7 +262,7 @@ themes      : ['Default', 'Basic', 'GitHub']
 
   <h2 class="ui dividing header">Variations</h2>
 
-  <div class="example" data-class="stackable">
+  <div class="example" data-class="!tablet stackable, stackable">
     <h4 class="ui header">Stackable</h4>
     <p>A step can stack vertically only on smaller screens</p>
     <div class="ui tablet stackable steps">

--- a/server/documents/elements/step.html.eco
+++ b/server/documents/elements/step.html.eco
@@ -121,8 +121,8 @@ themes      : ['Default', 'Basic', 'GitHub']
     </div>
   </div>
 
-  <div class="another example">
-    <p>Right vertical steps will show the active arrow to the left <span class="ui horizontal black label">New in 2.8.5</span></p>
+  <div class="another example" data-since="2.8.5">
+    <p>Right vertical steps will show the active arrow to the left</p>
     <div class="ui right vertical steps">
       <div class="completed step">
         <i class="truck icon"></i>
@@ -317,10 +317,9 @@ themes      : ['Default', 'Basic', 'GitHub']
     </div>
   </div>
 
-  <div class="example" data-class="stackable">
+  <div class="example" data-class="stackable" data-since="2.2.11">
     <h4 class="ui header">
       Unstackable
-      <div class="ui teal label">New in 2.2.11</div>
     </h4>
     <p>A step can prevent itself from stacking on mobile</p>
     <div class="ui unstackable steps">

--- a/server/documents/elements/step.html.eco
+++ b/server/documents/elements/step.html.eco
@@ -591,7 +591,7 @@ themes      : ['Default', 'Basic', 'GitHub']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-since="2.5">
     <h4 class="ui header">Inverted</h4>
     <p>A step's color can be inverted</p>
 

--- a/server/documents/elements/text.html.eco
+++ b/server/documents/elements/text.html.eco
@@ -44,10 +44,8 @@ type        : 'UI Element'
 
     <h2 class="ui dividing header">Variations</h2>
 
-    <div class="example">
-      <h4 class="ui header">Size
-        <div class="ui black label">New in 2.7.2</div>
-      </h4>
+    <div class="example" data-since="2.7.2">
+      <h4 class="ui header">Size</h4>
       <p>Text can vary in the same sizes as icons</p>
         <div class="ui segment">
           <p>Starting with <span class="ui mini red text">mini</span> text</p>

--- a/server/documents/globals/site.html.eco
+++ b/server/documents/globals/site.html.eco
@@ -47,10 +47,12 @@ themes      : ['Default', 'GitHub', 'Material']
   <div class="no example">
     <h4 class="ui header">Page Font</h4>
     <p>A site can specify styles for page content.</p>
+
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel tincidunt eros, nec venenatis ipsum. Nulla hendrerit urna ex, id sagittis mi scelerisque vitae. Vestibulum posuere rutrum interdum. Sed ut ullamcorper odio, non pharetra eros. Aenean sed lacus sed enim ornare vestibulum quis a felis. Sed cursus nunc sit amet mauris sodales tempus. Nullam mattis, dolor non posuere commodo, sapien ligula hendrerit orci, non placerat erat felis vel dui. Cras vulputate ligula ut ex tincidunt tincidunt. Maecenas eget gravida lorem. Nunc nec facilisis risus. Mauris congue elit sit amet elit varius mattis. Praesent convallis placerat magna, a bibendum nibh lacinia non.</p>
 
     <p>Fusce mollis sagittis elit ut maximus. Nullam blandit lacus sit amet luctus euismod. Duis luctus leo vel consectetur consequat. Phasellus ex ligula, pellentesque et neque vitae, elementum placerat eros. Proin eleifend odio nec velit lacinia suscipit. Morbi mollis ante nec dapibus gravida. In tincidunt augue eu elit porta, vel condimentum purus posuere. Maecenas tincidunt, erat sed elementum sagittis, tortor erat faucibus tellus, nec molestie mi purus sit amet tellus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Mauris a tincidunt metus. Fusce congue metus aliquam ex auctor eleifend.</p>
     <p>Ut imperdiet dignissim feugiat. Phasellus tristique odio eu justo dapibus, nec rutrum ipsum luctus. Ut posuere nec tortor eu ullamcorper. Etiam pellentesque tincidunt tortor, non sagittis nibh pretium sit amet. Sed neque dolor, blandit eu ornare vel, lacinia porttitor nisi. Vestibulum sit amet diam rhoncus, consectetur enim sit amet, interdum mauris. Praesent feugiat finibus quam, porttitor varius est egestas id.</p>
+
   </div>
 
   <div class="no example">

--- a/server/documents/globals/site.html.eco
+++ b/server/documents/globals/site.html.eco
@@ -32,7 +32,7 @@ themes      : ['Default', 'GitHub', 'Material']
 
   <h2 class="ui dividing header">Content</h2>
 
-  <div class="example">
+  <div class="no example">
 
     <h4 class="ui header">Headers</h4>
     <p>A site can define styles for headers</p>
@@ -44,26 +44,22 @@ themes      : ['Default', 'GitHub', 'Material']
     <h5>Fifth Header</h5>
   </div>
 
-  <div class="example">
+  <div class="no example">
     <h4 class="ui header">Page Font</h4>
     <p>A site can specify styles for page content.</p>
-
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel tincidunt eros, nec venenatis ipsum. Nulla hendrerit urna ex, id sagittis mi scelerisque vitae. Vestibulum posuere rutrum interdum. Sed ut ullamcorper odio, non pharetra eros. Aenean sed lacus sed enim ornare vestibulum quis a felis. Sed cursus nunc sit amet mauris sodales tempus. Nullam mattis, dolor non posuere commodo, sapien ligula hendrerit orci, non placerat erat felis vel dui. Cras vulputate ligula ut ex tincidunt tincidunt. Maecenas eget gravida lorem. Nunc nec facilisis risus. Mauris congue elit sit amet elit varius mattis. Praesent convallis placerat magna, a bibendum nibh lacinia non.</p>
 
     <p>Fusce mollis sagittis elit ut maximus. Nullam blandit lacus sit amet luctus euismod. Duis luctus leo vel consectetur consequat. Phasellus ex ligula, pellentesque et neque vitae, elementum placerat eros. Proin eleifend odio nec velit lacinia suscipit. Morbi mollis ante nec dapibus gravida. In tincidunt augue eu elit porta, vel condimentum purus posuere. Maecenas tincidunt, erat sed elementum sagittis, tortor erat faucibus tellus, nec molestie mi purus sit amet tellus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Mauris a tincidunt metus. Fusce congue metus aliquam ex auctor eleifend.</p>
     <p>Ut imperdiet dignissim feugiat. Phasellus tristique odio eu justo dapibus, nec rutrum ipsum luctus. Ut posuere nec tortor eu ullamcorper. Etiam pellentesque tincidunt tortor, non sagittis nibh pretium sit amet. Sed neque dolor, blandit eu ornare vel, lacinia porttitor nisi. Vestibulum sit amet diam rhoncus, consectetur enim sit amet, interdum mauris. Praesent feugiat finibus quam, porttitor varius est egestas id.</p>
-
   </div>
 
-  <div class="example">
+  <div class="no example">
     <h4 class="ui header">Text Selection</h4>
     <p>A site can specify text selection styles.</p>
     <div class="ui message ignored">Highlight the text below with your cursor to see a demonstration</div>
-
     <p>Fusce mollis sagittis elit ut maximus. Nullam blandit lacus sit amet luctus euismod. Duis luctus leo vel consectetur consequat. Phasellus ex ligula, pellentesque et neque vitae, elementum placerat eros. Proin eleifend odio nec velit lacinia suscipit. Morbi mollis ante nec dapibus gravida. In tincidunt augue eu elit porta, vel condimentum purus posuere. Maecenas tincidunt, erat sed elementum sagittis, tortor erat faucibus tellus, nec molestie mi purus sit amet tellus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Mauris a tincidunt metus. Fusce congue metus aliquam ex auctor eleifend.</p>
-
   </div>
-  <div class="example">
+  <div class="no example">
     <h4 class="ui header">Spacing</h4>
     <p>A site can define default spacing for headers and paragraphs</p>
 
@@ -74,7 +70,7 @@ themes      : ['Default', 'GitHub', 'Material']
     <p>Ut imperdiet dignissim feugiat. Phasellus tristique odio eu justo dapibus, nec rutrum ipsum luctus. Ut posuere nec tortor eu ullamcorper. Etiam pellentesque tincidunt tortor, non sagittis nibh pretium sit amet. Sed neque dolor, blandit eu ornare vel, lacinia porttitor nisi. Vestibulum sit amet diam rhoncus, consectetur enim sit amet, interdum mauris. Praesent feugiat finibus quam, porttitor varius est egestas id.</p>
   </div>
 
-  <div class="example">
+  <div class="no example">
     <h4 class="ui header">Links</h4>
     <p>A site can define link font formatting.</p>
     <p>Ut imperdiet dignissim feugiat. Phasellus tristique odio eu justo dapibus, nec rutrum ipsum luctus. Ut posuere nec tortor eu ullamcorper. <a href="#link">Etiam pellentesque</a> tincidunt tortor, non sagittis nibh pretium sit amet.</p>

--- a/server/documents/index.html.eco
+++ b/server/documents/index.html.eco
@@ -286,7 +286,7 @@ standalone : false
           <div class="ui vertical demo menu">
             <a class="active teal item">
               Inbox
-              <div class="ui teal label">1</div>
+              <div class="ui green label">1</div>
             </a>
             <a class="item">
               Trash
@@ -523,7 +523,7 @@ standalone : false
             molly@thebears.com
             <i class="delete icon"></i>
           </div>
-          <a class="ui teal label">
+          <a class="ui green label">
             <i class="mail icon"></i> 23 New
           </a>
           <a class="ui tag label">Dresses</a>

--- a/server/documents/index.html.eco
+++ b/server/documents/index.html.eco
@@ -180,9 +180,6 @@ standalone : false
       </h1>
       <p>Fomantic comes equipped with an intuitive inheritance system and high level theming variables that let you have complete design freedom.</p>
       <p>Develop your UI once, then deploy with the same code everywhere.</p>
-      <div class="ui large source button" style="display:none;">
-        <i class="docs code icon"></i> View Source
-      </div>
     </div>
     <div class="left aligned column">
       <div data-type="element" data-element="button" class="ui large floating dropdown theme button">

--- a/server/documents/introduction/build-tools.html.eco
+++ b/server/documents/introduction/build-tools.html.eco
@@ -325,8 +325,8 @@ type        : 'Introduction'
     </div>
   </div>
 
-  <div class="no example">
-    <h4>variation.variables <div class="ui black label">New in 2.8.1</div></h4>
+  <div class="no example" data-since="2.8.1">
+    <h4>variation.variables</h4>
     <p>You can disable specific variations of components allowing you to generate CSS files which only contain features you require. This makes your custom distribution files much smaller in size</p>
     <p>Most of the components also have a separate variable to decide which components should be rendered for which colors of your global color palette of colors.less or which sizes should be rendered.</p>
 
@@ -341,8 +341,8 @@ type        : 'Introduction'
     </div>
   </div>
 
-  <div class="no example">
-    <h4>colors.less <div class="ui black label">New in 2.7.0</div></h4>
+  <div class="no example" data-since="2.7.0">
+    <h4>colors.less</h4>
     <p>You can modify/define the global color palette entirely by adjusting a single LESS Map <code>@colors</code> in a custom <code>colors.less</code> file.</p>
     <p>Each color consists of a predefined set of properties used in all components. You can define whatever color name you want.</p>
     <div class="ui ignored info message">
@@ -462,10 +462,9 @@ type        : 'Introduction'
     <h4>Importing Gulp Tasks</h4>
     <p>See our <a href="/introduction/advanced-usage.html">recipes section</a> for examples on how to import individual gulp tasks into your custom Gulpfile.</p>
   </div>
-  <div class="no example">
+  <div class="no example" data-since="2.2">
     <h4>
       Auto-Install & Continuous Integration
-      <div class="ui teal horizontal label">New in 2.2</div>
     </h4>
     <p>We've added a new setting to <code>semantic.json</code> in 2.2 to help make working with a CLI, or other automated deployments more streamlined.</p>
     <p>Specifying <code>autoInstall: true</code> in an environments <code>semantic.json</code> configuration will prevent any user prompting when running <code>npx gulp install</code> allowing for automated deployment.</p>

--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -23,7 +23,7 @@ type        : 'Main'
   </p>
 
   <h2 class="ui dividing header">General Usage</h2>
-    <div class="example">
+    <div class="no example">
       <h4 class="ui header">Descriptive classnames</h4>
 
         <p>The base concept of Fomantic-UI is adding descriptional classnames to HTML nodes</p>
@@ -40,7 +40,7 @@ type        : 'Main'
             <div class="ui huge primary button">Button</div>
         </div>
     </div>
-    <div class="example">
+    <div class="no example">
       <h4 class="ui header">Class order</h4>
         <p>By specification, CSS allows to declare classnames in any order.</p>
         <div class="ui basic segment">

--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -39,6 +39,9 @@ type        : 'Main'
             <code>ui huge primary button</code>
             <div class="ui huge primary button">Button</div>
         </div>
+    </div>
+    <div class="example">
+      <h4 class="ui header">Class order</h4>
         <p>By specification, CSS allows to declare classnames in any order.</p>
         <div class="ui basic segment">
             <code>huge ui button primary</code>
@@ -61,12 +64,20 @@ type        : 'Main'
                 <div class="item">Where should the button be <b>labeled</b>? Left or right?</div>
             </div>
         </div>
-        <p>Some examples are labeled by <span class="ui small label"><i class="attention icon"></i>Word order required</span> to indicate the word order necessity.</p>
+        <p>Some examples are labeled by <span class="ui small wordorder label"><i class="attention icon"></i>Word order required</span> to indicate the word order necessity.</p>
         <p>So, as a general advise, just declare the classname order like a grammatical correct spoken description.</p>
         <div class="ui ignored warning message">
             <div class="header">Use <code>&lt;&gt;</code></div>
             <div class="content">
-            <p>While there are situations where a strict ordered class name list is important, in most cases it isn't. If in doubt, always watch out for the <code>&lt;&gt;</code> symbol displayed to the right of the examples which shows the source code when clicked and offers the correct classname order.</p>
+                <p>While there are situations where a strict ordered class name list is important, in most cases it isn't. If in doubt, always watch out for the <code>&lt;&gt;</code> symbol displayed to the right of the examples which shows the source code when clicked and highlights a possible required classname order.</p>
+                <div class="example" data-class="!left labeled, !right floated, button" data-use-content="true">
+                    <div class="code" data-type="html">
+                        <div class="ui left labeled right floated button">
+                            <div class="ui secondary label">Labeled</div>
+                            <div class="ui primary button">Button</div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -46,7 +46,7 @@ type        : 'Main'
         </div>
         <p>
             However, some combinations of FUI classnames <b>MUST</b> be declared in a strict predefined order divided by <b>ONE</b> space character.
-            This is sometimes needed to avoid decription confusion when the same classnames are used but have a different meaning.
+            This is sometimes needed to avoid description confusion when the same classnames are used but have a different meaning.
         </p>
         <div class="ui basic segment">
             <code>ui left labeled right floated button</code>
@@ -61,6 +61,7 @@ type        : 'Main'
                 <div class="item">Where should the button be <b>labeled</b>? Left or right?</div>
             </div>
         </div>
+        <p>Some examples are labeled by <span class="ui small label"><i class="attention icon"></i>Word order required</span> to indicate the word order necessity.</p>
         <p>So, as a general advise, just declare the classname order like a grammatical correct spoken description.</p>
         <div class="ui ignored warning message">
             <div class="header">Use <code>&lt;&gt;</code></div>

--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -84,7 +84,7 @@ type        : 'Main'
       <li class="item">NPM >= v6</li>
     </ul>
     <p>You can download NodeJS <a href="https://nodejs.org/en/download/" target="_blank">here</a>, NPM is installed with NodeJS.</p>
-    <div class="ui ignored info message"><i class="circle info icon"></i>Fomantic-UI also supports <code><a href="https://www.npmjs.com/package/yarn" target="_blank">yarn</a></code> as alternative package manager. <div class="ui black small horizontal label">New in 2.9.0</div></div>
+    <div class="ui ignored info message"><i class="circle info icon"></i>Fomantic-UI also supports <code><a href="https://www.npmjs.com/package/yarn" target="_blank">yarn</a></code> as alternative package manager. <div class="ui teal small horizontal label">New in 2.9.0</div></div>
     <br />
 
     <p>Once you have NodeJS and NPM installed, you will need to install <a href="https://npmjs.com/package/fomantic-ui">Fomantic-UI</a> as a dependency of your project.</p>

--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -70,9 +70,9 @@ type        : 'Main'
             <div class="header">Use <code>&lt;&gt;</code></div>
             <div class="content">
                 <p>While there are situations where a strict ordered class name list is important, in most cases it isn't. If in doubt, always watch out for the <code>&lt;&gt;</code> symbol displayed to the right of the examples which shows the source code when clicked and highlights a possible required classname order.</p>
-                <div class="example" data-class="!left labeled, !right floated, button" data-use-content="true">
+                <div class="example" data-class="!left labeled, !right floated, button, primary, secondary, tiny" data-use-content="true">
                     <div class="code" data-type="html">
-                        <div class="ui left labeled right floated button">
+                        <div class="ui left labeled tiny right floated button">
                             <div class="ui secondary label">Labeled</div>
                             <div class="ui primary button">Button</div>
                         </div>

--- a/server/documents/introduction/new.html.eco
+++ b/server/documents/introduction/new.html.eco
@@ -861,7 +861,7 @@ type        : 'Main'
       <i class="wifi huge icon"></i>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-class="colors">
       <h4 class="ui header">Colored Loaders</h4>
       <div class="ui active red inline loader"></div>
       <div class="ui active orange inline loader"></div>

--- a/server/documents/modules/accordion.html.eco
+++ b/server/documents/modules/accordion.html.eco
@@ -78,8 +78,8 @@ themes      : ['Default', 'Chubby']
         </div>
       </div>
     </div>
-    <div class="example">
-        <h4 class="ui header">Basic Styled <span class="ui black label">New in 2.9.0</span></h4>
+    <div class="example" data-since="2.9.0">
+        <h4 class="ui header">Basic Styled</h4>
         <p>A basic styled accordion limits the formatting to the header only</p>
         <div class="ui basic styled accordion">
           <div class="active title">
@@ -107,8 +107,8 @@ themes      : ['Default', 'Chubby']
         </div>
 
     </div>
-    <div class="example">
-      <h4 class="ui header">Tree <span class="ui black label">New in 2.9.0</span></h4>
+    <div class="example" data-since="2.9.0">
+      <h4 class="ui header">Tree</h4>
       <p>A tree accordion using <a href="#nested-accordions">nested accordions</a></p>
       <div class="ui tree accordion">
         <div class="active title">
@@ -263,8 +263,8 @@ themes      : ['Default', 'Chubby']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Compact <span class="ui black label">New in 2.9.0</span></h4>
+    <div class="example" data-since="2.9.0">
+      <h4 class="ui header">Compact</h4>
       <p>An accordion can reduce its padding to appear compact</p>
       <div class="ui segment">
         <div class="ui compact accordion">
@@ -582,8 +582,8 @@ themes      : ['Default', 'Chubby']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Right Icon <span class="ui black label">New in 2.9.0</span></h4>
+    <div class="example" data-since="2.9.0">
+      <h4 class="ui header">Right Icon</h4>
       <p>The dropdown icon can be placed to the right.</p>
       <div class="ui blue compact message">
         <div class="ui basic styled accordion">
@@ -613,8 +613,8 @@ themes      : ['Default', 'Chubby']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Without Javascript <span class="ui black label">New in 2.9.0</span></h4>
+    <div class="example" data-since="2.9.0">
+      <h4 class="ui header">Without Javascript</h4>
       <p>Using the accordion classes on <code>details/summary</code> HTML Elements, results in an accordion element made of pure CSS.</p>
       <details class="ui accordion">
         <summary class="title">

--- a/server/documents/modules/accordion.html.eco
+++ b/server/documents/modules/accordion.html.eco
@@ -263,7 +263,7 @@ themes      : ['Default', 'Chubby']
       </div>
     </div>
 
-    <div class="example" data-since="2.9.0">
+    <div class="example" data-since="2.9.0" data-class="!very compact, compact">
       <h4 class="ui header">Compact</h4>
       <p>An accordion can reduce its padding to appear compact</p>
       <div class="ui segment">

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -174,8 +174,8 @@ themes      : ['Default']
       ;
       </div>
     </div>
-    <div class="another example">
-      <p>You can also set the type or date using HTML markup <span class="ui black label">New in 2.8.0</span></p>
+    <div class="another example" data-since="2.8.0">
+      <p>You can also set the type or date using HTML markup</p>
       <div class="ui ignored info message">This could be useful when used with form validation without the need to instantiate the calendar via javascript before. Form validation recognizes a calendar component within the form and instantiates it automatically by using existing metadata values.</div>
       <div class="ui calendar" id="type_calendar" data-type="date" data-date="2019-12-24">
         <div class="ui input left icon">
@@ -311,8 +311,8 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Custom format <div class="ui small black label">New in 2.9.0</div></h4>
+    <div class="example" data-since="2.9.0">
+      <h4 class="ui header">Custom format</h4>
       <p>You can entirely change the date format by using a token string formatter.</p>
       <p>
         Tokens are placeholder characters for a specific output format. Fomantic-UI supports the following tokens:
@@ -646,8 +646,8 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="no example">
-      <h4 class="ui header">Context <span class="ui black label">New in 2.9.1</span></h4>
+    <div class="no example" data-since="2.9.1">
+      <h4 class="ui header">Context</h4>
       <p>A calendar popup inside an overflowing container does not allow the calendar popup to be shown completely, because it's still placed inside the same overflowing container of the triggering element by default.
          To solve this, you can now use the context setting and provide a (non-overflowing) parent element to move the calendar popup outside of the overflowing container and display the calendar popup properly.
          <br>
@@ -728,8 +728,8 @@ themes      : ['Default']
       ;
       </div>
     </div>
-    <div class="example">
-      <h4 class="ui header">Hours <span class="ui black label">New in 2.9.0</span></h4>
+    <div class="example" data-since="2.9.0">
+      <h4 class="ui header">Hours</h4>
       <p>Disabling specific hours of specific days which can optionally display a reason in popup on hover</p>
       <div class="ui calendar" id="disabledhours_calendar">
         <div class="ui fluid input left icon">
@@ -780,8 +780,8 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Whole Months <span class="ui black label">New in 2.8.4</span></h4>
+    <div class="example" data-since="2.8.4">
+      <h4 class="ui header">Whole Months</h4>
       <p>It's possible to disable all days of specific months</p>
       <div class="ui calendar" id="disabledmonth_calendar">
           <div class="ui input left icon">
@@ -807,8 +807,8 @@ themes      : ['Default']
           ;
       </div>
     </div>
-    <div class="example">
-      <h4 class="ui header">Whole Years <span class="ui black label">New in 2.8.4</span></h4>
+    <div class="example" data-since="2.8.4">
+      <h4 class="ui header">Whole Years</h4>
       <p>It's possible to disable all days of a whole year</p>
       <div class="ui calendar" id="disabledyear_calendar">
           <div class="ui input left icon">

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -1281,7 +1281,7 @@ themes      : ['Default']
       </thead>
       <tbody>
         <tr>
-          <td class="five wide">onBeforeChange(date, text, mode) <span class="ui tiny black label">New in 2.8.0</span></td>
+          <td class="five wide">onBeforeChange(date, text, mode) <span class="ui tiny teal label">New in 2.8.0</span></td>
           <td>active content</td>
           <td>Is called before a calendar date changes. <code>return false;</code> will cancel the change</td>
         </tr>

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -122,7 +122,7 @@ themes      : ['Default']
     </div>
 
     <h2 class="ui dividing header">States</h2>
-    <div class="example">
+    <div class="example" data-since="2.6.3">
       <h4 class="ui header">Disabled</h4>
       <p>A disabled calendar does not allow user interaction</p>
       <div class="ui disabled calendar">
@@ -584,7 +584,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-since="2.7.3">
       <h4 class="ui header">Select adjacent days</h4>
       <p>It's possible to also select adjacent days of the previous and next month in the current month view instead of being disabled</p>
       <div class="ui calendar" id="adjacentdays_calendar">
@@ -682,7 +682,7 @@ themes      : ['Default']
     </div>
 
     <h2 class="ui dividing header">Disabling specific Days</h2>
-    <div class="example">
+    <div class="example" data-since="2.6.4">
       <h4 class="ui header">Days of Week</h4>
       <p>Disable each Monday, Wednesday and Friday from selection</p>
       <div class="ui calendar" id="disableddaysofweek_calendar">
@@ -860,7 +860,7 @@ themes      : ['Default']
     </div>
 
     <h2 class="ui dividing header">Highlighting specific Days</h2>
-    <div class="example">
+    <div class="example" data-since="2.7.5">
       <h4 class="ui header">Event Dates</h4>
       <p>Mark specific days as events, giving them a different cell style and a tooltip message</p>
       <div class="ui calendar" id="eventdates_calendar">

--- a/server/documents/modules/dimmer.html.eco
+++ b/server/documents/modules/dimmer.html.eco
@@ -136,10 +136,9 @@ themes      : ['Default']
     <h2 class="ui dividing header">Variations</h2>
 
     <h3>Dimmable</h3>
-    <div class="example">
+    <div class="example" data-since="2.0">
       <h4 class="ui header">
         Blurring
-        <span class="ui teal label">New in 2.0</span>
       </h4>
       <p>A dimmable element can blur its contents</p>
       <div class="ui blurring segment">
@@ -165,10 +164,9 @@ themes      : ['Default']
     </div>
 
     <h3>Alignment</h3>
-    <div class="example">
+    <div class="example" data-since="2.3">
       <h4 class="ui header">
         Vertical Alignment
-        <span class="ui teal label">New in 2.3</span>
       </h4>
       <p>A dimmer can have its content top or bottom aligned.</p>
       <div class="ui segment">
@@ -370,8 +368,8 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="dimmerloader example">
-      <p>You can customize a loader in a dimmer via javascript <div class="ui black label">New in 2.7.0</div></p>
+    <div class="dimmerloader example" data-since="2.7.0">
+      <p>You can customize a loader in a dimmer via javascript</p>
       <div class="evaluated code">
           $('.dimmerloader.example .image')
           .dimmer({

--- a/server/documents/modules/dimmer.html.eco
+++ b/server/documents/modules/dimmer.html.eco
@@ -66,7 +66,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="content" data-use-content="true">
       <h4 class="ui header">Content Dimmer</h4>
       <p>A dimmer can display content</p>
       <div class="ui ignored info message">Since <div class="ui horizontal label">2.3</div> dimmers with content now only need a single wrapping <code>content</code> container.</div>
@@ -164,7 +164,7 @@ themes      : ['Default']
     </div>
 
     <h3>Alignment</h3>
-    <div class="example" data-since="2.3">
+    <div class="example" data-since="2.3" data-class="!top aligned, !bottom aligned">
       <h4 class="ui header">
         Vertical Alignment
       </h4>
@@ -229,7 +229,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="medium, light, very light">
       <h4 class="ui header">Dimmer Shades</h4>
       <p>A dimmer can be formatted to have a different depth of background shading using the additional classes <code>medium</code>, <code>light</code> or <code>very light</code></p>
       <div class="ignored ui info message">Also works in combination with <code>inverted</code></div>
@@ -251,7 +251,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="!top dimmer, !center dimmer, !bottom dimmer">
       <h4 class="ui header">Partially Dimmer</h4>
       <p>A dimmer can be displayed only partially and limited to the overall height of its content instead of the whole to be covered area. This can be used for example as a caption on any element by using <code>top dimmer</code>, <code>center dimmer</code> or <code>bottom dimmer</code></p>
       <div class="ui segment">

--- a/server/documents/modules/dimmer.html.eco
+++ b/server/documents/modules/dimmer.html.eco
@@ -251,7 +251,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-class="!top dimmer, !center dimmer, !bottom dimmer">
+    <div class="example" data-since="2.6.4" data-class="!top dimmer, !center dimmer, !bottom dimmer">
       <h4 class="ui header">Partially Dimmer</h4>
       <p>A dimmer can be displayed only partially and limited to the overall height of its content instead of the whole to be covered area. This can be used for example as a caption on any element by using <code>top dimmer</code>, <code>center dimmer</code> or <code>bottom dimmer</code></p>
       <div class="ui segment">

--- a/server/documents/modules/dimmer.html.eco
+++ b/server/documents/modules/dimmer.html.eco
@@ -597,7 +597,7 @@ themes      : ['Default']
           </td>
           <td>Named transition to use when animating menu in and out. Fade and slide down are available without including <a href="/modules/transition.html">ui transitions</a>
           <br>
-              <p>Alternatively you can provide an object to set individual values for hide/show transitions as well as hide/show duration <span class="ui black tiny label">New in 2.8.8</span>
+              <p>Alternatively you can provide an object to set individual values for hide/show transitions as well as hide/show duration <span class="ui teal tiny label">New in 2.8.8</span>
                   <div class="code">
                   {
                       showMethod   : 'fade',

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -978,7 +978,7 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="dropdown example">
+    <div class="dropdown example" data-class="!right floated, !left floated">
       <h4 class="ui header">Floated Content</h4>
       <p>A dropdown menu can contain floated content.</p>
       <div class="ui ignored info message">Floated content may stack to two lines without manually setting a width when or using a <code>fluid</code> dropdown
@@ -1485,7 +1485,7 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="dropdown example">
+    <div class="dropdown example" data-class="!very long, !very short, long, short">
       <h4 class="ui header">Height</h4>
       <p>A selection dropdown can be long (2x of default height) so that more items can be glanced.</p>
       <select class="ui search long dropdown" multiple>
@@ -1567,7 +1567,7 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="dropdown example">
+    <div class="dropdown example" data-class="!two column, !three column, !four column, !five column">
       <h4 class="ui header">Columnar Menu</h4>
       <p>A selection dropdown can allow menu to be equally divided so that more items can be glanced.</p>
       <select class="ui two column dropdown" multiple>

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -185,10 +185,9 @@ themes      : ['Default', 'GitHub', 'Material']
         </div>
     </div>
 
-    <div class="diacritics example">
+    <div class="diacritics example" data-since="2.7.2">
       <h4 class="ui header">
         Search ignoring Diacritics
-        <div class="ui black label">New in 2.7.2</div>
       </h4>
       <p>A selection dropdown can allow a user to ignore all Diacritics while searching.</p>
       <div class="ui ignored info message">
@@ -236,10 +235,9 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="dropdown example">
+    <div class="dropdown example" data-since="2.4.2">
       <h4 class="ui header">
         Clearable Selection
-        <div class="ui teal label">New in 2.4.2</div>
       </h4>
       <p>A clearable selection dropdown can allow a user to cancel to cancel a previous selection</p>
       <div class="ui clearable selection dropdown">
@@ -1082,8 +1080,8 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="actionable example">
-      <h4 class="ui header">Actionable <div class="ui black label">New in 2.9.0</div></h4>
+    <div class="actionable example" data-since="2.9.0">
+      <h4 class="ui header">Actionable</h4>
       <p>A dropdown menu can contain an actionable item which performs a custom callback once clicked instead of being selected itself</p>
       <div class="ui selection dropdown">
         <input type="hidden" name="">
@@ -1207,8 +1205,8 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Read-Only <span class="ui black label">New in 2.8.8</span></h4>
+    <div class="example" data-since="2.8.8">
+      <h4 class="ui header">Read-Only</h4>
       <p>A dropdown can be read-only and does not allow user interaction</p>
       <div class="ui read-only dropdown">
         Dropdown <i class="dropdown icon"></i>
@@ -1411,8 +1409,8 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="another dropdown example">
-      <p>The menu of a non-inverted dropdown can be inverted <span class="ui black label">New in 2.8.8</span></p>
+    <div class="another dropdown example" data-since="2.8.8">
+      <p>The menu of a non-inverted dropdown can be inverted</p>
         <div class="ui selection dropdown">
             <input type="hidden" name="choices">
             <div class="default text">Select choice</div>
@@ -1615,12 +1613,9 @@ themes      : ['Default', 'GitHub', 'Material']
 
     <h2 class="ui header">Selection Dropdowns</h2>
 
-    <div class="clearable example">
+    <div class="clearable example" data-since="2.4.0">
       <h4 class="ui header">
         Clearable
-        <div class="ui teal label">
-          New in 2.4.0
-        </div>
       </h4>
       <p>Using the clearable setting will let users remove their selection from a dropdown.</p>
 
@@ -1731,8 +1726,8 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="stuck example">
-      <h4 class="ui header">Stuck User Additions <span class="ui black label">New in 2.9.0</span></h4>
+    <div class="stuck example" data-since="2.9.0">
+      <h4 class="ui header">Stuck User Additions</h4>
       <p>While using <code>allowAdditions: true</code> together with <code>hideAdditions: false</code>, the first line indicating "add:" with the user addition may not be correctly displayed, depending on the container size and the distance between topmost visible item and menu's top item.
 
       <p>You can stick this addition line to the top of the menu by providing the additional <code>stuck</code> class.</p>
@@ -2550,10 +2545,9 @@ themes      : ['Default', 'GitHub', 'Material']
         ;
       </div>
     </div>
-    <div class="js example">
+    <div class="js example" data-since="2.2.12">
       <h4 class="ui header">
         Initializing with Javascript Only
-        <div class="ui teal label">New in 2.2.12</div>
       </h4>
       <p>You can specify a list of values in the settings object to avoid having to stub the html yourself.</p>
       <p>Adding <code>selected: true</code> to an item will have that item selected by default.</p>
@@ -2657,8 +2651,8 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
 
     </div>
-      <div class="no example">
-          <h4 class="ui header">Display images and/or icons by value setting<div class="ui black label">New in 2.7.7</div></h4>
+      <div class="no example" data-since="2.7.7">
+          <h4 class="ui header">Display images and/or icons by value setting</h4>
           <p>Images and/or icons in front of an item can be dynamically created by providing image paths, icon names or classnames for different styling</p>
           <div class="ui ignored info message">Also works in a JSON response from a <code><a href="#match-search-query-on-server">remote API call</a></code></div>
           <div class="evaluated code" data-type="javascript">
@@ -2736,8 +2730,8 @@ themes      : ['Default', 'GitHub', 'Material']
 
       </div>
 
-      <div class="no example">
-          <h4 class="ui header">Display a (vertical) description by value setting<div class="ui black label">New in 2.8.8</div></h4>
+      <div class="no example" data-since="2.8.8">
+          <h4 class="ui header">Display a (vertical) description by value setting</h4>
           <p>An additional item description (optionally displayed vertically) can be dynamically created by providing two extra attributes</p>
           <div class="ui ignored info message">Also works in a JSON response from a <code><a href="#match-search-query-on-server">remote API call</a></code></div>
           <div class="evaluated code" data-type="javascript">
@@ -2764,8 +2758,8 @@ themes      : ['Default', 'GitHub', 'Material']
           </div>
       </div>
 
-      <div class="no example">
-          <h4 class="ui header">Supporting image labels for multiselection<div class="ui black label">New in 2.7.7</div></h4>
+      <div class="no example" data-since="2.7.7">
+          <h4 class="ui header">Supporting image labels for multiselection</h4>
           <p>If needed, you can adjust the classname for multiselection labels to make use of <code><a href="/elements/label.html#image">image label</a></code></p>
           <div class="evaluated code" data-type="javascript">
               $('#imagelabels').dropdown({

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -1220,7 +1220,7 @@ themes      : ['Default', 'GitHub', 'Material']
 
     <h2 class="ui dividing header">Variations</h2>
 
-    <div class="dropdown example" data-class="size">
+    <div class="dropdown example" data-class="size" data-since="2.5">
       <h4 class="ui header">Size</h4>
       <p>A dropdown can have different sizes</p>
       <div class="ui mini selection dropdown">
@@ -1485,7 +1485,7 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="dropdown example" data-class="!very long, !very short, long, short">
+    <div class="dropdown example" data-since="2.7.3" data-class="!very long, !very short, long, short">
       <h4 class="ui header">Height</h4>
       <p>A selection dropdown can be long (2x of default height) so that more items can be glanced.</p>
       <select class="ui search long dropdown" multiple>
@@ -1567,7 +1567,7 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="dropdown example" data-class="!two column, !three column, !four column, !five column">
+    <div class="dropdown example" data-since="2.7.3" data-class="!two column, !three column, !four column, !five column">
       <h4 class="ui header">Columnar Menu</h4>
       <p>A selection dropdown can allow menu to be equally divided so that more items can be glanced.</p>
       <select class="ui two column dropdown" multiple>

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -84,7 +84,7 @@ themes      : ['Default', 'GitHub', 'Material']
       		iOS devices or firefox mobile do not show a scrollbar by default!
       	</div>
       	<p>
-      		To indicate more possible entries than shown, you may add the <code>scrollhint</code> class to the <code>menu</code> to show a short swipe animation on such devices.<br>When transforming <code>select</code> dropdowns this is done by using <code>className:{menu:'scrollhint menu'}</code> as a config setting <span class="ui black mini label">New in 2.8.7</span>
+      		To indicate more possible entries than shown, you may add the <code>scrollhint</code> class to the <code>menu</code> to show a short swipe animation on such devices.<br>When transforming <code>select</code> dropdowns this is done by using <code>className:{menu:'scrollhint menu'}</code> as a config setting <span class="ui teal mini label">New in 2.8.7</span>
       	</p>
       </div>
       <div class="ui selection dropdown">
@@ -2603,7 +2603,7 @@ themes      : ['Default', 'GitHub', 'Material']
         ;
       </div>
       <br/>
-      <p>You can also add submenus by adding <code>type: 'menu'</code> or <code>type: 'left menu'</code> and another <code>values</code> object to the item itself. <span class="ui black label">New in 2.8.8</span></p>
+      <p>You can also add submenus by adding <code>type: 'menu'</code> or <code>type: 'left menu'</code> and another <code>values</code> object to the item itself. <span class="ui teal label">New in 2.8.8</span></p>
       <div class="code" data-label="Javascript" data-type="javascript">
           $('.ui.dropdown').dropdown({
             values: [
@@ -3368,12 +3368,12 @@ themes      : ['Default', 'GitHub', 'Material']
         </tr>
         <tr>
           <td>ignoreCase</td>
-          <td>false<div class="ui label">New in 2.2.13</div></td>
+          <td>false<div class="ui teal label">New in 2.2.13</div></td>
           <td>Whether values with non matching cases should be treated as identical when adding them to a dropdown.</td>
         </tr>
         <tr>
           <td>ignoreSearchCase</td>
-          <td>true<div class="ui label">New in 2.8.0</div></td>
+          <td>true<div class="ui teal label">New in 2.8.0</div></td>
           <td>Whether values with non matching cases should be treated as identical when filtering the items.</td>
         </tr>
         <tr>
@@ -3491,7 +3491,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>ignoreDiacritics</td>
           <td>false</td>
           <td>When activated, searches will also match results for base diacritic letters. For example when searching for 'a', it will also match 'á' or 'â' or 'å' and so on...
-              It will also ignore diacritics for the searchterm, so if searching for 'ó', it will match 'ó', but also 'o', 'ô' or 'õ' and so on...<div class="ui black label">New in 2.7.2</div><div class="ui red label">Not available in IE</div></td>
+              It will also ignore diacritics for the searchterm, so if searching for 'ó', it will match 'ó', but also 'o', 'ô' or 'õ' and so on...<div class="ui teal label">New in 2.7.2</div><div class="ui red label">Not available in IE</div></td>
         </tr>
       </tbody>
     </table>
@@ -3670,7 +3670,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>Specifying to "true" will use a fuzzy full text search, setting to "exact" will force the exact search to be matched somewhere in the string, setting to "false" will only match start of string.</td>
         </tr>
         <tr>
-          <td>hideDividers <div class="ui label">New in 2.4.0</div></td>
+          <td>hideDividers <div class="ui teal label">New in 2.4.0</div></td>
           <td>false</td>
           <td>How to handle dividers in the dropdown while searching. Dividers are defined as all siblings of items that match the <a href="#dom-settings">divider selector</a>
             <div class="ui vertical divided list">

--- a/server/documents/modules/embed.html.eco
+++ b/server/documents/modules/embed.html.eco
@@ -69,7 +69,7 @@ type        : 'UI Module'
 
     <h2 class="ui dividing header">Types</h2>
 
-    <div class="embed example">
+    <div class="embed example" data-class="embed">
       <h4 class="ui header">YouTube</h4>
       <p>An embed can be used to display <a href="https://www.youtube.com" target="_blank">YouTube</a> Content</p>
 
@@ -81,7 +81,7 @@ type        : 'UI Module'
 
     </div>
 
-    <div class="embed example">
+    <div class="embed example" data-class="embed">
       <h4 class="ui header">Vimeo</h4>
       <p>An embed can be used to display <a href="https://www.vimeo.com" target="_blank">Vimeo</a> content.</p>
 
@@ -93,7 +93,7 @@ type        : 'UI Module'
 
     </div>
 
-    <div class="embed example">
+    <div class="embed example" data-class="embed">
       <h4 class="ui header">Custom Content</h4>
       <p>An embed can display any web content</p>
       <div class="ui info ignored message">Embeds use an intrinsic aspect ratios to embed content responsively. Content will preserve their intrinsic aspect ratio for all browser sizes responsively</div>
@@ -108,9 +108,9 @@ type        : 'UI Module'
 
     <h2 class="ui dividing header">Variations</h2>
 
-    <div class="embed example">
+    <div class="embed example" data-class="square,4:3,16:9,21:9">
       <h4 class="ui header">Aspect Ratio</h4>
-      <p>An embed can specify an alternative aspect ratio</p>
+      <p>An embed can specify an alternative aspect ratio out of <code>square</code>, <code>4:3</code>, <code>16:9</code> or <code>21:9</code></p>
       <div class="ui 4:3 embed"
         data-source="youtube"
         data-id="HTZudKi36bo"

--- a/server/documents/modules/flyout.html.eco
+++ b/server/documents/modules/flyout.html.eco
@@ -62,7 +62,7 @@ themes      : ['Default']
 
     <h2 class="ui dividing header">Variations</h2>
 
-    <div class="no example" data-class="thin, very thin, wide">
+    <div class="no example" data-class="thin, !very thin, !very wide, wide">
       <h4 class="ui header">Width</h4>
       <p>A flyout can specify its width.</p>
       <div class="code" data-type="html">
@@ -74,7 +74,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="another no example">
+    <div class="another no example" data-class="!two wide, !five wide, !eight wide, !twelve wide">
       <p>Width can also be defined like the <a href="/collections/grid.html">ui grid</a> system.</p>
       <div class="code" data-type="html">
         <div class="ui two wide flyout"></div>
@@ -117,7 +117,7 @@ themes      : ['Default']
 
     </div>
 
-    <div class="no example">
+    <div class="no example" data-use-content="true">
       <h4 class="ui header">
           Center Aligned
       </h4>
@@ -141,7 +141,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-use-content="true">
       <h4 class="ui header">
           Left Actions
       </h4>
@@ -165,7 +165,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-class="basic" data-use-content="true">
       <h4 class="ui header">
           Basic Header and Actions
       </h4>

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -1091,7 +1091,7 @@ themes      : ['Default', 'Material']
       </tbody>
     </table>
 
-    <h2 class="ui dividing header">Config Templates</h2> <span class="ui black label">New in 2.8.8</span>
+    <h2 class="ui dividing header">Config Templates</h2> <span class="ui teal label">New in 2.8.8</span>
     <p>A config template is a special behavior to immediately show preconfigured temporary modals. Three basic templates are included: <code>alert</code>, <code>confirm</code>, <code>prompt</code> as equivalents to existing vanilla JS variants, but with more possibilities to customize the look & feel. </p>
     <div class="ui info message">
       Config template modals will be always autoshown, so no manual <code>show</code> is needed)
@@ -1244,12 +1244,12 @@ themes      : ['Default', 'Material']
         <tr>
           <td>restoreFocus</td>
           <td>true</td>
-          <td>When false, the last focused element, before the modal was shown, will not get refocused again when the modal hides. This could prevent unwanted scrolling behaviors after closing a modal. <div class="ui tiny black label">new in 2.7.2</div></td>
+          <td>When false, the last focused element, before the modal was shown, will not get refocused again when the modal hides. This could prevent unwanted scrolling behaviors after closing a modal. <div class="ui tiny teal label">new in 2.7.2</div></td>
         </tr>
         <tr>
           <td>autoShow</td>
           <td>false</td>
-          <td>When true, immediately shows the modal at instantiation time. <div class="ui tiny black label">new in 2.8.8</div></td>
+          <td>When true, immediately shows the modal at instantiation time. <div class="ui tiny teal label">new in 2.8.8</div></td>
         </tr>
         <tr>
           <td>observeChanges</td>
@@ -1318,7 +1318,7 @@ themes      : ['Default', 'Material']
             scale
           </td>
           <td>Named transition to use when animating menu in and out, full list can be found in <a href="/modules/transition.html">ui transitions</a> docs.<br>
-            <p>Alternatively you can provide an object to set individual values for hide/show transitions as well as hide/show duration. <span class="ui black tiny label">New in 2.8.8</span>
+            <p>Alternatively you can provide an object to set individual values for hide/show transitions as well as hide/show duration. <span class="ui teal tiny label">New in 2.8.8</span>
                 <div class="code">
                 {
                     showMethod   : 'fade',

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -577,7 +577,7 @@ themes      : ['Default', 'Material']
       ;
       </div>
     </div>
-    <div class="no example" data-class="!overlay fullscreen">
+    <div class="no example" data-since="2.7.3" data-class="!overlay fullscreen">
       <h4 class="ui header">Overlay Full Screen</h4>
       <p>A modal can overlay the entire screen</p>
       <div class="ui ignored info message">

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -485,7 +485,7 @@ themes      : ['Default', 'Material']
 
     <h2 class="ui dividing header">Content</h2>
 
-    <div class="no example">
+    <div class="no example" data-use-content="true">
       <h4 class="ui header">
         Header
       </h4>
@@ -514,7 +514,7 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example" data-since="2.0>
+    <div class="no example" data-since="2.0" data-use-content="true">
       <h4 class="ui header">
         Image Content
       </h4>
@@ -535,7 +535,7 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-use-content="true">
       <h4 class="ui header">
         Actions
       </h4>
@@ -568,7 +568,7 @@ themes      : ['Default', 'Material']
 
     <h2 class="ui dividing header">Variations</h2>
 
-    <div class="no example">
+    <div class="no example" data-class="fullscreen">
       <h4 class="ui header">Full Screen</h4>
       <p>A modal can use the entire size of the screen</p>
       <div class="code" data-demo="true" data-eval="$('.fullscreen.modal').not('.overlay').modal('show')">
@@ -577,7 +577,7 @@ themes      : ['Default', 'Material']
       ;
       </div>
     </div>
-    <div class="no example">
+    <div class="no example" data-class="!overlay fullscreen">
       <h4 class="ui header">Overlay Full Screen</h4>
       <p>A modal can overlay the entire screen</p>
       <div class="ui ignored info message">
@@ -635,7 +635,7 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example" data-since="2.2.11">
+    <div class="no example" data-since="2.2.11" data-use-content="true">
       <h4 class="ui header">
         Scrolling Content
       </h4>
@@ -655,7 +655,7 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example" data-since="2.8.8">
+    <div class="no example" data-since="2.8.8" data-use-content="true">
       <h4 class="ui header">
           Center Aligned
       </h4>
@@ -679,7 +679,7 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example" data-since="2.9.0">
+    <div class="no example" data-since="2.9.0" data-use-content="true">
       <h4 class="ui header">
           Left Actions
       </h4>
@@ -703,7 +703,7 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example" data-since="2.9.0">
+    <div class="no example" data-since="2.9.0" data-class="basic" data-use-content="true">
       <h4 class="ui header">
           Basic Header and Actions
       </h4>
@@ -757,7 +757,7 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example" data-since="2.7.3">
+    <div class="no example" data-since="2.7.3" data-class="!top aligned">
       <h4 class="ui header">
           Top or Bottom aligned
       </h4>

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -514,12 +514,9 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.0>
       <h4 class="ui header">
         Image Content
-        <span class="ui teal label">
-          New in 2.0
-        </span>
       </h4>
       <p>A modal can contain image content</p>
       <div class="ui ignored info message">
@@ -638,10 +635,9 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.2.11">
       <h4 class="ui header">
         Scrolling Content
-        <div class="ui teal label">New in 2.2.11</div>
       </h4>
       <p>A modal can use the entire size of the screen</p>
       <div class="code" data-type="html" data-variation="scrolling">
@@ -659,10 +655,9 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.8.8">
       <h4 class="ui header">
           Center Aligned
-          <div class="ui black label">New in 2.8.8</div>
       </h4>
       <p>You can center align the header, the content or even actions individually</p>
       <div class="code" data-type="html">
@@ -684,10 +679,9 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.9.0">
       <h4 class="ui header">
           Left Actions
-          <div class="ui black label">New in 2.9.0</div>
       </h4>
       <p>You can also place the action buttons to the left</p>
       <div class="code" data-type="html">
@@ -709,10 +703,9 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.9.0">
       <h4 class="ui header">
           Basic Header and Actions
-          <div class="ui black label">New in 2.9.0</div>
       </h4>
       <p>Header and/or Actions can also appear on the same basic background as the content</p>
       <div class="code" data-type="html">
@@ -749,10 +742,9 @@ themes      : ['Default', 'Material']
 
     <h2 class="ui dividing header">Examples</h2>
 
-    <div class="no example">
+    <div class="no example" data-since="2.3">
       <h4 class="ui header">
         Disabling Vertical Centering
-        <div class="ui horizontal teal label">New in 2.3</div>
       </h4>
       <p>When your modal has dynamic content, or multiple steps, it can make sense to disable centering so content doesn't jump around vertically when its height changes.</p>
       <div class="code" data-demo="true">
@@ -765,10 +757,9 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.7.3">
       <h4 class="ui header">
           Top or Bottom aligned
-          <div class="ui horizontal teal label">New in 2.7.3</div>
       </h4>
       <p>If you leave the <code>centered</code> option to the default <code>true</code>, you can also force positioning of the modal by adding additional classes <code>top aligned</code> (which equals to the usage of <code>centered:false</code>) or <code>bottom aligned</code> to the modal itself</p>
       <div class="ui ignored info message">
@@ -940,8 +931,8 @@ themes      : ['Default', 'Material']
 
     <h2 class="ui dividing header">Initializing a modal</h2>
 
-    <div class="no example">
-      <h4 class="ui header">Via Javascript properties<span class="ui black label">New in 2.8.8</span></h4>
+    <div class="no example" data-since="2.8.8">
+      <h4 class="ui header">Via Javascript properties</h4>
       <p>You can create temporary modals without the need to create markup on your own. Temporary modals will be removed from the DOM once closed by default if there isn't a custom <code>onHidden</code> callback given.</p>
       <div class="ui ignored info message">jQuery short notation <code>$.modal()</code> support was added in 2.9.0. If you want this for older FUI versions add
           <code>
@@ -1003,8 +994,8 @@ themes      : ['Default', 'Material']
       </div>
     </div>
 
-    <div class="no example">
-      <h4 class="ui header">Reuse existing modal with new content <span class="ui black label">New in 2.8.8</span></h4>
+    <div class="no example" data-since="2.8.8">
+      <h4 class="ui header">Reuse existing modal with new content</h4>
       <p>You can prepare a modal markup as a general template and reuse it's general style but provide actual content via js properties.</p>
       <div class="code" data-demo="true">
         var now = new Date();now.setDate(now.getDate()+Math.floor(Math.random() * 31 + 1));

--- a/server/documents/modules/nag.html.eco
+++ b/server/documents/modules/nag.html.eco
@@ -31,7 +31,7 @@ type        : 'UI Module'
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-use-content="true">
       <h4 class="ui header">Title</h4>
       <p>A nag can have a title</p>
       <div class="ui nag">
@@ -41,7 +41,7 @@ type        : 'UI Module'
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="fixed">
      <h4 class="ui header">Fixed Nag</h4>
       <p>A fixed nag appears at the top of the screen</p>
       <div class="ui fixed nag" id="fixednag">
@@ -60,7 +60,7 @@ type        : 'UI Module'
           ;
       </div>
     </div>
-    <div class="example">
+    <div class="example" data-class="bottom fixed">
       <p>A fixed nag can appear at the bottom of the screen</p>
       <div class="ui bottom fixed nag" id="bottomfixednag">
         Look, I am a bottom fixed nag!
@@ -75,7 +75,7 @@ type        : 'UI Module'
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="overlay">
      <h4 class="ui header">Overlay Nag</h4>
       <p>An overlay nag is absolute positioned and appears at the top of the parent DOM node</p>
       <div class="ui segment">
@@ -87,7 +87,7 @@ type        : 'UI Module'
           <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
       </div>
     </div>
-    <div class="example">
+    <div class="example" data-class="bottom overlay">
       <p>An overlay nag can appear at the bottom of the parent node</p>
       <div class="ui segment">
           <div class="ui bottom overlay nag">

--- a/server/documents/modules/nag.html.eco
+++ b/server/documents/modules/nag.html.eco
@@ -112,7 +112,7 @@ type        : 'UI Module'
         </div>
     </div>
     <h2 class="ui dividing header">Variations</h2>
-    <div class="example">
+    <div class="example" data-class="colors">
         <h4 class="ui header">Colored</h4>
         <p>A nag can be formatted to be different colors</p>
         <div class="ui red nag"><div class="title">Red</div><i class="close icon"></i></div> <p></p>

--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -336,7 +336,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="!very wide" data-use-content="true">
       <h4 class="ui header">Width</h4>
       <p>A popup can be extra wide to allow for longer content</p>
       <i class="circular heart icon link" data-content="Hello. This is a wide pop-up which allows for lots of content with additional space. You can fit a lot of words here and the paragraphs will be pretty wide." data-variation="wide"></i>

--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -269,7 +269,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example" data-since="2.9.1">
+    <div class="example" data-since="2.9.1" data-class="colors">
         <h4 class="ui header">Colored Tooltip</h4>
         <p>A tooltip can have different colors via the <code>data-variation</code> attribute.</p>
         <div class="ui spaced compact wrapping buttons">
@@ -404,7 +404,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="colored example" data-since="2.9.1">
+    <div class="colored example" data-since="2.9.1" data-class="colors">
         <h4 class="ui header">Colored</h4>
         <p>A popup can have different colors</p>
         <div class="ui spaced compact wrapping buttons">

--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -106,9 +106,8 @@ themes      : ['Default']
 
     <h3 class="ui header">No Javascript</h3>
 
-    <div class="example">
+    <div class="example" data-since="2.2">
       <h4 class="ui header">Tooltip
-        <div class="ui teal horizontal label">New in 2.2</div>
       </h4>
       <p>An element can specify a simple tooltip that can appear without javascript via the <code>data-tooltip</code> attribute. If the tooltip should be shown inverted, also add the <code>data-inverted</code> attribute.</p>
       <div class="ui warning ignored message">
@@ -242,8 +241,8 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Multiline Tooltip <span class="ui black label">New in 2.9.1</span></h4>
+    <div class="example" data-since="2.9.1">
+      <h4 class="ui header">Multiline Tooltip</h4>
       <p>A tooltip can show multiple lines via predefined line breaks in the HTML code and adding <code>multiline</code> to the <code>data-variation</code> attribute.</p>
       <div class="ui ignored warning message">
         <div class="header">
@@ -262,16 +261,16 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Visible Tooltip <div class="ui black label">New in 2.9.3</div></h4>
+    <div class="example" data-since="2.9.3">
+      <h4 class="ui header">Visible Tooltip</h4>
       <p>A tooltip can be shown visible all the time by adding <code>visible</code> to the <code>data-variation</code> attribute.</p>
       <div class="ui button" data-tooltip="I am visible all the time" data-variation="visible" data-position="right center">
         Important Button
       </div>
     </div>
 
-    <div class="example">
-        <h4 class="ui header">Colored Tooltip<span class="ui black label">New in 2.9.1</span></h4>
+    <div class="example" data-since="2.9.1">
+        <h4 class="ui header">Colored Tooltip</h4>
         <p>A tooltip can have different colors via the <code>data-variation</code> attribute.</p>
         <div class="ui spaced compact wrapping buttons">
             <button data-variation="red" data-tooltip="Red" class="ui button">Red</button>
@@ -292,8 +291,8 @@ themes      : ['Default']
 
     <h2 class="ui dividing header">States</h2>
 
-    <div class="loading example">
-        <h4 class="ui header">Loading <div class="ui black label">New in 2.9.2</div></h4>
+    <div class="loading example" data-since="2.9.2">
+        <h4 class="ui header">Loading</h4>
         <p>A popup may show its content is being loaded</p>
         <div class="ui grid">
           <div class="doubling two column row">
@@ -405,8 +404,8 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="colored example">
-        <h4 class="ui header">Colored<span class="ui black label">New in 2.9.1</span></h4>
+    <div class="colored example" data-since="2.9.1">
+        <h4 class="ui header">Colored</h4>
         <p>A popup can have different colors</p>
         <div class="ui spaced compact wrapping buttons">
             <button class="ui button">Red</button>
@@ -620,9 +619,8 @@ themes      : ['Default']
 
     <h2 class="ui dividing header">Examples</h2>
 
-    <div class="boundary example">
+    <div class="boundary example" data-since="2.2">
       <h4 class="ui header">Specifying Popup Boundaries
-        <div class="ui horizontal teal label">New in 2.2</div>
       </h4>
       <p>Popups now include a new setting <code>boundary</code> that let you specify that a popup should not escape the boundary of another section. This can be useful in complex paned layouts</p>
       <p>Additionally popups can now specify a scroll context, to allow for scroll containers other than window to cause a clicked popup to hide on scroll.</p>

--- a/server/documents/modules/progress.html.eco
+++ b/server/documents/modules/progress.html.eco
@@ -23,7 +23,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
 
     <h2 class="ui dividing header">Types</h2>
 
-    <div class="example">
+    <div class="example" data-class="progress">
       <h4 class="ui header">Standard</h4>
       <p>A standard progress bar</p>
       <div class="ui progress">
@@ -64,7 +64,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-use-content="true">
       <h4 class="ui header">Progress</h4>
       <p>A progress bar can contain a text value indicating current progress</p>
       <div class="ui progress">
@@ -74,7 +74,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       </div>
     </div>
 
-    <div class="example" data-since="2.7.6">
+    <div class="example" data-since="2.7.6" data-class="centered progress" data-use-content="true">
       <h4 class="ui header">Centered Progress Text</h4>
       <p>The text inside a progress can be centered</p>
       <div class="ui progress">
@@ -84,7 +84,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-use-content="true">
       <h4 class="ui header">Label</h4>
       <p>A progress element can contain a label</p>
       <div class="ui progress">
@@ -95,7 +95,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="multiple">
       <h4 class="ui header">Multiple Bars</h4>
       <p>A progress element can have multiple bars.</p>
       <div class="ui multiple progress" data-percent="50,0,10,20">
@@ -106,7 +106,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       </div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="multiple">
       <h4 class="ui header">Multiple Bars with Text (Proportion)</h4>
       <p>A progress bar can contain text values indicating current proportion.</p>
       <div class="ui multiple progress" data-total="200" data-value="60,30,20,30">
@@ -189,7 +189,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       </div>
     </div>
 
-    <div class="example" data-since="2.7.6">
+    <div class="example" data-since="2.7.6" data-class="filling indeterminate, swinging indeterminate, sliding indeterminate">
       <h4 class="ui header">Indeterminate</h4>
       <p>A progress bar can be shown in different indeterminate states.</p>
       <div class="ui warning ignored message">
@@ -216,7 +216,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
           </div>
       </div>
     </div>
-    <div class="another example">
+    <div class="example" data-class="slow, fast">
       <p>Indeterminate progress can also vary in speed</p>
       <div class="ui blue slow indeterminate progress">
           <div class="bar">

--- a/server/documents/modules/progress.html.eco
+++ b/server/documents/modules/progress.html.eco
@@ -95,7 +95,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       </div>
     </div>
 
-    <div class="example" data-class="multiple">
+    <div class="example" data-since="2.7.3" data-class="multiple">
       <h4 class="ui header">Multiple Bars</h4>
       <p>A progress element can have multiple bars.</p>
       <div class="ui multiple progress" data-percent="50,0,10,20">

--- a/server/documents/modules/progress.html.eco
+++ b/server/documents/modules/progress.html.eco
@@ -74,8 +74,8 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Centered Progress Text<span class="ui small black label">New in 2.7.6</span></h4>
+    <div class="example" data-since="2.7.6">
+      <h4 class="ui header">Centered Progress Text</h4>
       <p>The text inside a progress can be centered</p>
       <div class="ui progress">
         <div class="bar">
@@ -189,8 +189,8 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       </div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Indeterminate<span class="ui small black label">New in 2.7.6</span></h4>
+    <div class="example" data-since="2.7.6">
+      <h4 class="ui header">Indeterminate</h4>
       <p>A progress bar can be shown in different indeterminate states.</p>
       <div class="ui warning ignored message">
         The <code>indeterminate</code> progress state is not supposed to be used in combination with <code>multiple</code> progress bars
@@ -232,8 +232,8 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
 
     <h2 class="ui dividing header">Variations</h2>
 
-    <div class="example">
-      <h4 class="ui header">Right aligned <div class="ui black label">New in 2.8.8</div></h4>
+    <div class="example" data-since="2.8.8">
+      <h4 class="ui header">Right aligned</h4>
       <p>A progress bar can be right aligned growing to the left</p>
       <div class="ui right aligned active progress">
         <div class="bar">

--- a/server/documents/modules/rating.html.eco
+++ b/server/documents/modules/rating.html.eco
@@ -52,7 +52,7 @@ themes      : ['Default']
 
     </div>
 
-    <div class="example" data-since="2.7">
+    <div class="example" data-since="2.7" data-class="colors">
       <h4 class="ui header">Color</h4>
       <p>You can specify any color of the FUI color palette</p>
       <div class="ui red rating" data-icon="star" data-rating="1" data-max-rating="7"></div>

--- a/server/documents/modules/rating.html.eco
+++ b/server/documents/modules/rating.html.eco
@@ -26,7 +26,7 @@ themes      : ['Default']
 
     <div class="example">
       <h4 class="ui header">Rating
-        <span class="ui teal label">Flexbox</span>
+        <span class="ui orange label">Flexbox</span>
       </h4>
       <p>A basic rating </p>
       <div class="ui rating" data-max-rating="1"></div>

--- a/server/documents/modules/rating.html.eco
+++ b/server/documents/modules/rating.html.eco
@@ -32,8 +32,8 @@ themes      : ['Default']
       <div class="ui rating" data-max-rating="1"></div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Icon <div class="ui black label">New in 2.7</div></h4>
+    <div class="example" data-since="2.7">
+      <h4 class="ui header">Icon</h4>
       <p>You can use any available icon as rating indicator</p>
 
       <div class="ui yellow rating" data-icon="star" data-rating="2"></div>
@@ -52,8 +52,8 @@ themes      : ['Default']
 
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Color <div class="ui black label">New in 2.7</div></h4>
+    <div class="example" data-since="2.7">
+      <h4 class="ui header">Color</h4>
       <p>You can specify any color of the FUI color palette</p>
       <div class="ui red rating" data-icon="star" data-rating="1" data-max-rating="7"></div>
       <br><br>
@@ -83,8 +83,8 @@ themes      : ['Default']
       <br><br>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Partial Ratings <div class="ui black label">New in 2.8.0</div></h4>
+    <div class="example" data-since="2.8.0">
+      <h4 class="ui header">Partial Ratings</h4>
       <p>You can use decimal values for showing partially filled ratings</p>
       <div class="ui ignored warning message">
         <p>Partial ratings require jQuery version >3.2 and are only supported by browsers with support for <a href="https://caniuse.com/#feat=css-variables">CSS Variables</a> and <a href="https://caniuse.com/#feat=mdn-css_types_image_gradient_linear-gradient_interpolation_hints">Gradient Midpoints</a>. Unsupported browsers will use a rounded down value.</p>

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -109,10 +109,9 @@ type        : 'UI Module'
     </div>
 
 
-    <div class="local-category example">
+    <div class="local-category example" data-since="2.3">
       <h4 class="ui header">
         Local Category Search
-        <div class="ui teal label">New in 2.3</div>
       </h4>
       <p>A search can look for category results inside a static local source.</p>
       <div class="ui ignored info message">
@@ -152,10 +151,9 @@ type        : 'UI Module'
       </div>
     </div>
 
-    <div class="diacritics example">
+    <div class="diacritics example" data-since="2.7.2">
       <h4 class="ui header">
         Search ignoring Diacritics
-        <div class="ui black label">New in 2.7.2</div>
       </h4>
       <p>A selection dropdown can allow a user to ignore all Diacritics while searching.</p>
       <div class="ui ignored info message">
@@ -286,10 +284,9 @@ type        : 'UI Module'
 
     <h2 class="ui dividing header">Variations</h2>
 
-    <div class="category example">
+    <div class="category example" data-since="2.3.1">
       <h4 class="ui header">
         Disabled
-        <div class="ui teal label">New in 2.3.1</div>
       </h4>
       <p>A search can show it is currently unable to be interacted with</p>
       <div class="ui disabled category search">

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -21,7 +21,7 @@ type        : 'UI Module'
 
     <h2 class="ui dividing header">Types</h2>
 
-    <div class="standard example">
+    <div class="standard example" data-class="search">
       <h4 class="ui header">Standard</h4>
       <p>A search can display a set of results</p>
       <div class="ui search">
@@ -313,7 +313,7 @@ type        : 'UI Module'
       </div>
     </div>
 
-    <div class="local example">
+    <div class="local example" data-class="!very short, !very long, short, long">
       <h4 class="ui header">Height</h4>
       <p>A search can be very short (0.75x of default height) so that more results can be glanced.</p>
 	  <div class="ui ignored info message">
@@ -349,7 +349,7 @@ type        : 'UI Module'
       </div>
     </div>
 
-    <div class="category example">
+    <div class="category example" data-class="!right aligned">
       <h4 class="ui header">Aligned</h4>
       <p>A search can have its results aligned to its left or right container edge</p>
       <div class="ui right aligned category search">

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -313,7 +313,7 @@ type        : 'UI Module'
       </div>
     </div>
 
-    <div class="local example" data-class="!very short, !very long, short, long">
+    <div class="local example" data-since="2.8.5" data-class="!very short, !very long, short, long">
       <h4 class="ui header">Height</h4>
       <p>A search can be very short (0.75x of default height) so that more results can be glanced.</p>
 	  <div class="ui ignored info message">

--- a/server/documents/modules/shape.html.eco
+++ b/server/documents/modules/shape.html.eco
@@ -25,7 +25,7 @@ themes      : ['default']
 
     <h2 class="ui dividing header">Types</h2>
 
-    <div class="example">
+    <div class="example" data-class="shape">
       <h4 class="ui header">Shape</h4>
       <p>A shape is a three dimensional object including any flat content as a side.</p>
 

--- a/server/documents/modules/sidebar.html.eco
+++ b/server/documents/modules/sidebar.html.eco
@@ -118,7 +118,7 @@ themes      : ['Default']
 
     </div>
 
-    <div class="no example" data-class="thin, very thin, wide, very wide">
+    <div class="no example" data-class="thin, !very thin, wide, !very wide">
       <h4 class="ui header">Width</h4>
       <p>A sidebar can specify its width</p>
       <div class="ui message">

--- a/server/documents/modules/sidebar.html.eco
+++ b/server/documents/modules/sidebar.html.eco
@@ -53,9 +53,9 @@ themes      : ['Default']
       ;
       </div>
     </div>
-    <div class="another example" data-class="labeled icon menu" data-use-content="true">
+    <div class="no example" data-class="labeled icon sidebar" data-use-content="true">
       <div class="code" data-type="html" data-escape="true">
-        &lt;div class=&quot;ui left demo vertical inverted sidebar labeled icon menu&quot;&gt;
+        &lt;div class=&quot;ui left demo vertical inverted labeled icon sidebar menu&quot;&gt;
           &lt;a class=&quot;item&quot;&gt;
             &lt;i class=&quot;home icon&quot;&gt;&lt;/i&gt;
             Home
@@ -93,6 +93,7 @@ themes      : ['Default']
     </div>
 
     <h3>Pusher</h3>
+    <p>The pusher is the element that will be pushed away by the sidebar and should contain your site content. See <a href="#page-structure">Page Structure</a></p>
 
     <div class="no example" data-class="dimmed" data-use-content="true">
       <h4 class="ui header">Dimmed</h4>
@@ -117,7 +118,7 @@ themes      : ['Default']
 
     </div>
 
-    <div class="no example">
+    <div class="no example" data-class="thin, very thin, wide, very wide">
       <h4 class="ui header">Width</h4>
       <p>A sidebar can specify its width</p>
       <div class="ui message">

--- a/server/documents/modules/slider.html.eco
+++ b/server/documents/modules/slider.html.eco
@@ -176,7 +176,7 @@ themes      : ['Default']
       <div class="ui vertical slider" style="height: 200px;"></div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="colors">
       <h4 class="ui header">Colored</h4>
       <p>A slider can be different colors</p>
       <div class="ui red slider"></div>

--- a/server/documents/modules/slider.html.eco
+++ b/server/documents/modules/slider.html.eco
@@ -34,19 +34,19 @@ themes      : ['Default']
       ;
       </div>
     </div>
-    <div class="another example">
+    <div class="example">
       <h4 class="ui header">Labeled slider</h4>
       <p>A slider that show its labels</p>
       <div class="ui labeled slider"></div>
     </div>
-    <div class="another example">
+    <div class="example">
       <h4 class="ui header">Labeled ticked slider</h4>
       <p>A slider that show its labels and ticks</p>
       <div class="ui labeled ticked slider"></div>
     </div>
 
     <div class="example">
-        <h4 class="ui header">Label at the bottom</h4>
+        <h4 class="ui header">Bottom aligned labeled</h4>
         <p>A slider can display the labels below the track</p>
         <div class="ui bottom aligned labeled slider"></div>
     </div>
@@ -194,7 +194,7 @@ themes      : ['Default']
       <div class="ui black slider"></div>
     </div>
 
-    <div class="example">
+    <div class="example" data-class="inverted, colors">
       <h4 class="ui header">Inverted Colored</h4>
       <p>A slider can be different colors while inverted</p>
       <div class="ui inverted segment">

--- a/server/documents/modules/slider.html.eco
+++ b/server/documents/modules/slider.html.eco
@@ -51,8 +51,8 @@ themes      : ['Default']
         <div class="ui bottom aligned labeled slider"></div>
     </div>
 
-    <div class="example">
-        <h4 class="ui header">Restricted Labels <div class="ui black label">New in 2.9.3</div></h4>
+    <div class="example" data-since="2.9.3">
+        <h4 class="ui header">Restricted Labels</h4>
         <p>You can restrict the display of labels to only the ones you want</p>
         <div class="ui labeled ticked slider" id="restrictedlabelsslider"></div>
     </div>
@@ -142,8 +142,8 @@ themes      : ['Default']
       <div class="ui reversed slider"></div>
     </div>
 
-    <div class="example">
-      <h4 class="ui header">Thumb Tooltips <div class="ui black label">New in 2.9.3</div></h4>
+    <div class="example" data-since="2.9.3">
+      <h4 class="ui header">Thumb Tooltips</h4>
       <p>The slider thumbs can show a tooltip on hover containing the current value</p>
       <div class="ui slider" id="slider-tooltip-1"></div>
     </div>

--- a/server/documents/modules/tab.html.eco
+++ b/server/documents/modules/tab.html.eco
@@ -24,7 +24,7 @@ themes      : ['Default']
       Type
     </h2>
 
-    <div class="example">
+    <div class="example" data-class="tab">
       <h4 class="ui header">
         Tab
       </h4>
@@ -75,7 +75,7 @@ themes      : ['Default']
       Variations
     </h2>
 
-    <div class="center example">
+    <div class="center example" data-class="center" data-use-content="true">
       <h4 class="ui header">
         Centered Item
       </h4>

--- a/server/documents/modules/toast.html.eco
+++ b/server/documents/modules/toast.html.eco
@@ -50,7 +50,7 @@ themes      : ['Default']
         </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.6.3">
         <h4 class="ui header">Progress Bar</h4>
         <p>You can attach a progress bar to your toast.</p>
         <div class="code" data-demo="true">
@@ -203,7 +203,7 @@ themes      : ['Default']
         </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.6.3">
         <h4 class="ui header">Use Message Style</h4>
         <p>You can use all of the styles and colors from the message component</p>
         <div class="code" data-demo="true">
@@ -219,7 +219,7 @@ themes      : ['Default']
         </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.6.3">
         <h4 class="ui header">Increasing Progress Bar</h4>
         <p>The progress bar could be be raised instead of lowered</p>
         <div class="code" data-demo="true">
@@ -233,7 +233,7 @@ themes      : ['Default']
         </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.6.3">
         <h4 class="ui header">Color Variants</h4>
         <p>You can use all of the usual color names</p>
         <div class="code" data-demo="true">
@@ -464,7 +464,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.6.3">
       <h4 class="ui header">Individual icon</h4>
       <p>Use whatever you like from the included FontAwesome gallery</p>
       <div class="code" data-demo="true">
@@ -503,7 +503,7 @@ themes      : ['Default']
         </div>
     </div>
 
-    <div class="no example">
+    <div class="no example" data-since="2.6.3">
       <h4 class="ui header">Close Icon</h4>
       <p>You can force the user to click a close Icon instead of clicking anywhere on the toast to close it</p>
       <div class="code" data-demo="true">

--- a/server/documents/modules/toast.html.eco
+++ b/server/documents/modules/toast.html.eco
@@ -119,8 +119,8 @@ themes      : ['Default']
         ;
         </div>
     </div>
-    <div class="no example">
-          <h4 class="ui header">Attached Position<span class="ui black label">New in 2.8.8</span></h4>
+    <div class="no example" data-since="2.8.8">
+          <h4 class="ui header">Attached Position</h4>
           <p>A toast can have an attached position which will show the toast over the whole width of the screen. Just like notifications on mobile devices.</p>
           <div class="ui warning message">
             Attached positions with centered content only support attached actions. See the  <a href="#actions-and-centered-and-attached-position">examples tab</a> for more info.
@@ -143,8 +143,8 @@ themes      : ['Default']
             ;
           </div>
       </div>
-    <div class="no example">
-      <h4 class="ui header">Direction <span class="ui black label">New in 2.8.8</span></h4>
+    <div class="no example" data-since="2.8.8">
+      <h4 class="ui header">Direction</h4>
       <p>Toasts can stack horizontal</p>
       <div class="code" data-demo="true">
       $.toast({
@@ -155,8 +155,8 @@ themes      : ['Default']
       ;
       </div>
     </div>
-    <div class="no example">
-          <h4 class="ui header">Center Aligned<span class="ui black label">New in 2.8.8</span></h4>
+    <div class="no example" data-since="2.8.8">
+          <h4 class="ui header">Center Aligned</h4>
           <p>The toasts content can be shown center aligned.</p>
           <div class="ui warning message">
               Centered content in <a href="#attached-position">attached toasts</a> only support attached actions. See the  <a href="#actions-and-centered-and-attached-position">examples tab</a> for more info.
@@ -282,8 +282,8 @@ themes      : ['Default']
     </div>
 
     <h2 class="ui dividing header">Actions</h2>
-    <div class="no example">
-        <h4 class="ui header">General<div class="ui black label">New in 2.8.0</div></h4>
+    <div class="no example" data-since="2.8.0">
+        <h4 class="ui header">General</h4>
         <p>Define click actions to your toast by providing a text and/or icon, optional class and click handler.</p>
         <div class="ui ignored message">
             <ul class="ui list">
@@ -340,8 +340,8 @@ themes      : ['Default']
         ;
         </div>
     </div>
-    <div class="no example">
-        <h4 class="ui header">Centered<div class="ui black label">New in 2.8.8</div></h4>
+    <div class="no example" data-since="2.8.8">
+        <h4 class="ui header">Centered</h4>
         <p>The actions buttons can also be shown <code>centered</code></p>
         <div class="code" data-demo="true">
           $.toast({
@@ -476,8 +476,8 @@ themes      : ['Default']
       ;
       </div>
     </div>
-    <div class="no example">
-        <h4 class="ui header">Image<div class="ui black label">New in 2.8.0</div></h4>
+    <div class="no example" data-since="2.8.0">
+        <h4 class="ui header">Image</h4>
         <p>Provide an image path to display it just like the icon does. <br> Adjust the image via the separate <code>classImage</code> setting</p>
         <div class="ui ignored message">
             For image sizes, only <code>mini</code>, <code>tiny</code>, <code>small</code> and <code>avatar</code> are supported
@@ -586,8 +586,8 @@ themes      : ['Default']
         ;
         </div>
     </div>
-    <div class="example">
-      <h4 class="ui header">Template <span class="ui black label">New in 2.8.8</span></h4>
+    <div class="example" data-since="2.8.8">
+      <h4 class="ui header">Template</h4>
       <p>You can reuse a dom template and provide its content via setting parameters</p>
       <div class="ui pink toast" id="domtemplate" >
           <img class="ui image avatar">
@@ -684,8 +684,8 @@ themes      : ['Default']
 
       <h2 class="ui dividing header">Interaction</h2>
 
-      <div class="no example">
-          <h4 class="ui header">Prevent pausing <div class="ui black label">New in 2.8.0</div></h4>
+      <div class="no example" data-since="2.8.0">
+          <h4 class="ui header">Prevent pausing</h4>
           <p>The default behavior when hovering over the toast is to pause decreasing of the display time.<br>
               You can force the toast to not pause by setting <code>pauseOnHover</code> to <code>false</code></p>
           <div class="code" data-demo="true">
@@ -696,8 +696,8 @@ themes      : ['Default']
             });
           </div>
       </div>
-      <div class="no example">
-          <h4 class="ui header">Prevent closing <div class="ui black label">New in 2.8.0</div></h4>
+      <div class="no example" data-since="2.8.0">
+          <h4 class="ui header">Prevent closing</h4>
           <p>The default behavior when clicking on a toast is to close it.<br>
               You can force the toast to not do this by setting <code>closeOnClick</code> to <code>false</code></p>
           <div class="ui ignored info message">
@@ -717,8 +717,8 @@ themes      : ['Default']
           </div>
       </div>
 
-    <div class="no example">
-        <h4 class="ui header">Access created toast<div class="ui black label">New in 2.8.0</div></h4>
+    <div class="no example" data-since="2.8.0">
+        <h4 class="ui header">Access created toast</h4>
         <p>As each call to <code>.toast()</code> returns the instance of the created toast, you are able to interact with the displayed toast via javascript <a href="#behaviors">behaviors</a> </p>
         <button class="ui pink button" id="jsaccess_toast_init">
             Open pink toast first

--- a/server/documents/modules/transition.html.eco
+++ b/server/documents/modules/transition.html.eco
@@ -35,10 +35,9 @@ type        : 'UI Module'
         </div>
       </div>
 
-      <div class="no example">
+      <div class="no example" data-since="2.3">
         <h4 class="ui header">
           Zoom
-          <div class="ui teal label">New in 2.3</div>
         </h4>
         <p>An element can zoom into view from far away</p>
         <div class="code" data-demo="true">
@@ -207,10 +206,9 @@ type        : 'UI Module'
             </div>
         </div>
       </div>
-      <div class="no example">
+      <div class="no example" data-since="2.9.1">
         <h4 class="ui header">
           Pulsating
-        <div class="ui black label">New in 2.9.1</div>
         </h4>
         <p>An element can have pulsating edges. This works best on circular or square elements.</p>
         <div class="ui ignored message">
@@ -288,10 +286,9 @@ type        : 'UI Module'
         ;
         </div>
       </div>
-      <div class="no example">
+      <div class="no example" data-since="2.3">
         <h4 class="ui header">
           Glow
-          <div class="ui teal label">New in 2.3</div>
         </h4>
         <p>An element can glow to show its position in a page.</p>
         <div class="code" data-demo="true">

--- a/server/documents/views/advertisement.html.eco
+++ b/server/documents/views/advertisement.html.eco
@@ -5,8 +5,8 @@ css         : 'ad'
 element     : 'advertisement'
 elementType : 'view'
 
-title       : 'Advertisement'
-description : 'An ad displays third-party promotional content'
+title       : 'Ad'
+description : 'An ad ("Advertisement") displays third-party promotional content'
 type        : 'UI View'
 
 ---
@@ -18,65 +18,11 @@ type        : 'UI View'
 
   <h2 class="ui dividing header">Types</h2>
 
-  <div class="example">
+  <div class="no example" data-class="ad" data-use-content="true">
     <h4 class="ui header">Ad</h4>
     <p>A standard ad</p>
-    <div class="ui ignored message">The following example uses a basic <a href="https://support.google.com/adsense/answer/181947?ctx=as2&rd=2&ref_topic=29033" target="_blank">AdSense implementation</a>. Your code will vary depending on your ad network.</div>
-    <div class="ui medium rectangle ad">
-      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-      <ins class="adsbygoogle"
-           style="display:inline-block;width:300px;height:250px"
-           data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-           data-ad-slot="XXXXXXXXXX"></ins>
-      <script>
-      (adsbygoogle = window.adsbygoogle || []).push({});
-      </script>
-    </div>
-    <div class="ui leaderboard ad">
-      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-      <!-- Leaderboard -->
-      <ins class="adsbygoogle"
-           style="display:inline-block;width:728px;height:90px"
-           data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-           data-ad-slot="XXXXXXXXXX"></ins>
-      <script>
-      (adsbygoogle = window.adsbygoogle || []).push({});
-      </script>
-    </div>
-    <div class="ui banner ad">
-      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-      <!-- Banner -->
-      <ins class="adsbygoogle"
-           style="display:inline-block;width:468px;height:60px"
-           data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-           data-ad-slot="XXXXXXXXXX"></ins>
-      <script>
-      (adsbygoogle = window.adsbygoogle || []).push({});
-      </script>
-    </div>
-    <div class="existing code">
-      <div class="ui medium rectangle ad">
-        <!-- Ad Code Goes Here
-        <ins class="adsbygoogle"
-             style="display:inline-block;width:300px;height:250px"
-             data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-             data-ad-slot="XXXXXXXXXX"></ins>
-        <script>
-        (adsbygoogle = window.adsbygoogle || []).push({});
-        </script>
-        !-->
-      </div>
-      <div class="ui leaderboard ad">
-      <!-- Leaderboard
-      <ins class="adsbygoogle"
-           style="display:inline-block;width:728px;height:90px"
-           data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
-           data-ad-slot="XXXXXXXXXXXXXXXX"></ins>
-      <script>
-      (adsbygoogle = window.adsbygoogle || []).push({});
-      </script>
-      !-->
-      </div>
+    <div class="ui ignored message">The following example shows basic <a href="https://support.google.com/adsense/answer/181947?ctx=as2&rd=2&ref_topic=29033" target="_blank">AdSense implementation</a> usage. Your code will vary depending on your ad network.</div>
+    <div class="code">
       <div class="ui banner ad">
       <!-- Banner
       <ins class="adsbygoogle"
@@ -91,11 +37,11 @@ type        : 'UI View'
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="test, !medium reactangle, !large reactangle, banner, leaderboard, !half page" data-use-content="true">
     <h4 class="ui header">Common Units</h4>
     <p>An advertisement can appear in common ad unit sizes</p>
     <div class="ui ignored info message">
-      These additional examples use the <code>test</code> variation to appear on the page. <code>ui ad</code> is best used as a wrapper for third party ad network content like <a href="https://www.google.com/adsense/start/" target="_blank">AdSense</a> or <a href="https://www.google.com/doubleclick/publishers/welcome/" target="_blank">DoubleClick</a>.
+      These additional examples use the <a href="#test"><code>test</code></a> variation to appear on the page. <code>ui ad</code> is best used as a wrapper for third party ad network content like <a href="https://www.google.com/adsense/start/" target="_blank">AdSense</a> or <a href="https://www.google.com/doubleclick/publishers/welcome/" target="_blank">DoubleClick</a>.
     </div>
     <div class="ui medium rectangle test ad" data-text="Medium Rectangle"></div>
     <div class="ui banner test ad" data-text="Banner"></div>
@@ -104,7 +50,7 @@ type        : 'UI View'
     <div class="ui half page test ad" data-text="Half Page"></div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!mobile leaderboard, mobile, banner" data-use-content="true">
     <h4 class="ui header">Mobile</h4>
     <p>An ad can use common mobile ad sizes</p>
     <div class="ui ignored info message">Mobile ads will automatically only appear on mobile browser viewports</div>
@@ -113,14 +59,14 @@ type        : 'UI View'
   </div>
 
 
-  <div class="example">
+  <div class="example" data-class="!vertical rectangle, !small rectangle" data-use-content="true">
     <h4 class="ui header">Rectangle</h4>
     <p>An ad can use a common rectangle ad unit size</p>
     <div class="ui vertical rectangle test ad" data-text="Vertical Rectangle"></div>
     <div class="ui small rectangle test ad" data-text="Small Rectangle"></div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!square button, !small button" data-use-content="true">
     <h4 class="ui header">Button</h4>
     <p>An ad can use button ad unit size</p>
     <div class="ui button test ad" data-text="Button"></div>
@@ -128,14 +74,14 @@ type        : 'UI View'
     <div class="ui small button test ad" data-text="Small Button"></div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!wide skyscraper" data-use-content="true">
     <h4 class="ui header">Skyscraper</h4>
     <p>An ad can use skyscraper ad unit size</p>
     <div class="ui skyscraper test ad" data-text="Skyscraper"></div>
     <div class="ui wide skyscraper test ad" data-text="Wide Skyscraper"></div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!vertical banner, !top banner, !half banner, !large mobile banner" data-use-content="true">
     <h4 class="ui header">Banner</h4>
     <p>An ad can use banner ad unit size</p>
     <div class="ui banner test ad" data-text="Banner"></div>
@@ -144,7 +90,7 @@ type        : 'UI View'
     <div class="ui half banner test ad" data-text="Half Banner"></div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!large leaderboard, !mobile leaderboard, billboard, leaderboard" data-use-content="true">
     <h4 class="ui header">Leaderboards</h4>
     <p>An ad can use leaderboard ad unit size</p>
     <div class="ui leaderboard test ad" data-text="Leaderboard"></div>
@@ -152,13 +98,13 @@ type        : 'UI View'
     <div class="ui billboard test ad" data-text="Billboard"></div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Panorama</h4>
     <p>An ad can use panorama ad unit size</p>
     <div class="ui panorama test ad" data-text="Panorama"></div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Netboard</h4>
     <p>An ad can use netboard ad unit size</p>
     <div class="ui netboard test ad" data-text="Netboard"></div>
@@ -168,13 +114,13 @@ type        : 'UI View'
 
   <h2 class="ui dividing header">Variations</h2>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Centered</h4>
     <p>An advertisement can appear centered</p>
     <div class="ui centered banner test ad"></div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Test</h4>
     <p>A advertisement can be formatted to help verify placement</p>
     <div class="ui info ignored message">You can adjust the text displayed for your test ad placement by changing the value of <code>data-text</code>

--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -496,8 +496,8 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
 
   <h2 class="ui dividing header">States</h2>
 
-  <div class="example">
-    <h4 class="ui header">Disabled <span class="ui black label">New in 2.8.8</span></h4>
+  <div class="example" data-since="2.8.8">
+    <h4 class="ui header">Disabled</h4>
     <p>A card may show its content is disabled</p>
     <div class="ui disabled card">
         <div class="content">
@@ -517,8 +517,8 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
         </div>
     </div>
   </div>
-  <div class="example">
-    <h4 class="ui header">Loading <span class="ui black label">New in 2.8.8</span></h4>
+  <div class="example" data-since="2.8.8">
+    <h4 class="ui header">Loading</h4>
     <p>A card may show its content is being loaded</p>
     <div class="ui loading card">
         <div class="content">
@@ -967,8 +967,8 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
       </a>
     </div>
   </div>
-  <div class="example">
-    <h4 class="ui header">Basic <div class="ui small black label">New in 2.9.0</div></h4>
+  <div class="example" data-since="2.9.0">
+    <h4 class="ui header">Basic</h4>
     <p>A basic card does not have a border and also supports full color background</p>
     <div class="ui four basic cards">
       <a class="primary card">

--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -808,7 +808,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-since="2.5">
     <h4 class="ui header">Inverted</h4>
     <p>Card's colors can be inverted</p>
     <div class="ui inverted segment">

--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -200,7 +200,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
 
   <h2 class="ui dividing header">Content</h2>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Content Block</h4>
     <p>A card can contain blocks of content</p>
     <div class="ui card">
@@ -320,7 +320,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Header</h4>
     <p>A card can contain a header</p>
     <div class="ui cards">
@@ -354,7 +354,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="meta" data-use-content="true">
     <h4 class="ui header">Metadata</h4>
     <p>A card can contain content metadata</p>
 
@@ -434,7 +434,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="star,like" data-use-content="true">
     <h4 class="ui header">Approval</h4>
     <p>A card can contain a like or star action.</p>
     <div class="ui card">
@@ -459,7 +459,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Description</h4>
     <p>A card can contain a description with one or more paragraphs</p>
     <div class="ui card">
@@ -474,7 +474,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Extra Content</h4>
     <p>A card can contain extra content meant to be formatted separately from the main content</p>
     <div class="ui card">
@@ -760,7 +760,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!right floated,!left floated,floated" data-use-content="true">
     <h4 class="ui header">Floated Content</h4>
     <p>Any content element can be floated left or right</p>
     <div class="ui ignored info message">
@@ -786,7 +786,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!center aligned,!left aligned,!right aligned" data-use-content="true">
     <h4 class="ui header">Text Alignment</h4>
     <p>Any element inside a card can have its text alignment specified</p>
     <div class="ui ignored info message">

--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -886,7 +886,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored</h4>
     <p>A card can specify a color</p>
     <div class="ui four cards">

--- a/server/documents/views/comment.html.eco
+++ b/server/documents/views/comment.html.eco
@@ -671,7 +671,7 @@ themes      : ['Default', 'Chubby']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-since="2.5">
     <h4 class="ui header">Inverted</h4>
     <p>Comments' colors can be inverted</p>
     <div class="ui inverted segment">

--- a/server/documents/views/comment.html.eco
+++ b/server/documents/views/comment.html.eco
@@ -129,7 +129,7 @@ themes      : ['Default', 'Chubby']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Metadata</h4>
     <p>A comment can contain metadata about the comment, an arbitrary amount of metadata may be defined.</p>
     <div class="ui comments">
@@ -154,7 +154,7 @@ themes      : ['Default', 'Chubby']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Actions</h4>
     <p>A comment can contain an list of actions a user may perform related to this comment.</p>
     <div class="ui comments">

--- a/server/documents/views/feed.html.eco
+++ b/server/documents/views/feed.html.eco
@@ -347,7 +347,7 @@ themes      : ['Default', 'Timeline']
         </div>
       </div>
     </div>
-    <div class="example">
+    <div class="example" data-since="2.5">
       <h4 class="ui header">Inverted</h4>
       <p>A feed's color can be inverted</p>
 

--- a/server/documents/views/feed.html.eco
+++ b/server/documents/views/feed.html.eco
@@ -134,7 +134,7 @@ themes      : ['Default', 'Timeline']
 
   <h2 class="ui dividing header">Content</h2>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Label</h4>
     <p>An event can contain an image or icon label</p>
     <div class="ui feed">
@@ -165,7 +165,7 @@ themes      : ['Default', 'Timeline']
   </div>
 
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Date</h4>
     <p>An event or an event summary can contain a date</p>
     <div class="ui feed">
@@ -202,7 +202,7 @@ themes      : ['Default', 'Timeline']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="summary, extra text, extra images" data-use-content="true">
     <h4 class="ui header">Additional information</h4>
     <p>An event can contain additional information like a set of images or text</p>
     <div class="ui feed">

--- a/server/documents/views/item.html.eco
+++ b/server/documents/views/item.html.eco
@@ -25,7 +25,7 @@ themes      : ['Default']
   <div class="example">
     <h4 class="ui header">
       Items
-      <span class="ui teal label">Flexbox</span>
+      <span class="ui orange label">Flexbox</span>
     </h4>
     <p>A group of items.</p>
     <div class="ui ignored positive icon message">

--- a/server/documents/views/item.html.eco
+++ b/server/documents/views/item.html.eco
@@ -22,7 +22,7 @@ themes      : ['Default']
 
   <h2 class="ui dividing header">Types</h2>
 
-  <div class="example">
+  <div class="example" data-class="item, items" data-use-content="true">
     <h4 class="ui header">
       Items
       <span class="ui orange label">Flexbox</span>
@@ -75,7 +75,7 @@ themes      : ['Default']
 
   <h2 class="ui dividing header">Content</h2>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Image</h4>
     <p>An item can contain an image</p>
     <div class="ui divided items">
@@ -97,7 +97,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Content</h4>
     <p>An item can contain content</p>
     <div class="ui divided items">
@@ -128,7 +128,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Header</h4>
     <p>An item can contain a header</p>
     <div class="ui items">
@@ -159,7 +159,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="meta" data-use-content="true">
     <h4 class="ui header">Metadata</h4>
     <p>An item can contain content metadata</p>
     <div class="ui ignored info message">
@@ -278,7 +278,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="extra" data-use-content="true">
     <h4 class="ui header">Extra Content</h4>
     <p>An item can contain extra content meant to be formatted separately from the main content</p>
     <div class="ui items">
@@ -446,7 +446,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!very relaxed, relaxed">
     <h4 class="ui header">Relaxed</h4>
     <p>A group of items can relax its padding to provide more negative space</p>
     <div class="ui relaxed items">
@@ -506,7 +506,7 @@ themes      : ['Default']
   </div>
 
 
-  <div class="example">
+  <div class="example" data-class="link" data-use-content="true">
     <h4 class="ui header">Link Item</h4>
     <p>An item can be formatted so that the entire contents link to another page</p>
     <div class="ui link items">
@@ -546,7 +546,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!middle aligned, !bottom aligned, content" data-use-content="true">
     <h4 class="ui header">Vertical Alignment</h4>
     <p>Content can specify its vertical alignment</p>
     <div class="ui ignored info message">
@@ -587,7 +587,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!right floated, !left floated">
     <h4 class="ui header">Floated Content</h4>
     <p>Any content element can be floated left or right</p>
     <div class="ui ignored info message">

--- a/server/documents/views/statistic.html.eco
+++ b/server/documents/views/statistic.html.eco
@@ -45,7 +45,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="statistics">
     <h4 class="ui header">Statistic Group</h4>
     <p>A group of statistics</p>
     <div class="ui statistics">
@@ -119,7 +119,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-use-content="true">
     <h4 class="ui header">Label</h4>
     <p>A statistic can contain a label to help provide context for the presented value</p>
     <div class="ui statistic">
@@ -546,7 +546,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="!right floated,!left floated,floated">
     <h4 class="ui header">Floated</h4>
     <p>An statistic can sit to the left or right of other content</p>
 

--- a/server/documents/views/statistic.html.eco
+++ b/server/documents/views/statistic.html.eco
@@ -176,7 +176,7 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
+  <div class="example" data-class="colors">
     <h4 class="ui header">Colored</h4>
     <p>A statistic can be formatted to be different colors</p>
     <div class="ui statistics">

--- a/server/documents/views/statistic.html.eco
+++ b/server/documents/views/statistic.html.eco
@@ -533,8 +533,8 @@ themes      : ['Default']
     </div>
   </div>
 
-  <div class="example">
-    <h4 class="ui header">Fluid <span class="ui black label">New in 2.9.1</span></h4>
+  <div class="example" data-since="2.9.1">
+    <h4 class="ui header">Fluid</h4>
     <p>A fluid statistic occupies the whole container width. It's a simpler alternative to a <code>one statistic</code> group.</p>
     <div class="ui fluid statistic">
       <div class="value">

--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -806,17 +806,16 @@ semantic.ready = function() {
       }
       // Add common variations
       classes = classes.replace('text alignment', "left aligned, right aligned, justified, center aligned");
-      classes = classes.replace('floated', "!right floated,!left floated,floated");
       classes = classes.replace('floating', "!right floated,!left floated,floated");
       classes = classes.replace('horizontally aligned', "left aligned, center aligned, right aligned, justified");
       classes = classes.replace('vertically aligned', "top aligned, middle aligned, bottom aligned");
       classes = classes.replace('vertically attached', "attached");
       classes = classes.replace('horizontally attached', "attached");
-      classes = classes.replace('padded', "very padded, padded");
-      classes = classes.replace('relaxed', "very relaxed, relaxed");
+      classes = classes.replace('padded', "!very padded, padded");
+      classes = classes.replace('relaxed', "!very relaxed, relaxed");
       classes = classes.replace('attached', "left attached,right attached,top attached,bottom attached,attached");
-      classes = classes.replace('thin', "very thin, thin");
-      classes = classes.replace('wide', "!one wide,!two wide,!three wide,!four wide,!five wide,!six wide,!seven wide,!eight wide,!nine wide,!ten wide,!eleven wide,!twelve wide,!thirteen wide,!fourteen wide,!fifteen wide,!sixteen wide,!very wide,wide");
+      classes = classes.replace('thin', "!very thin, thin");
+      classes = classes.replace('wide', "one wide,two wide,three wide,four wide,five wide,six wide,seven wide,eight wide,nine wide,ten wide,eleven wide,twelve wide,thirteen wide,fourteen wide,fifteen wide,sixteen wide,!very wide,wide");
       classes = classes.replace('count', "one,two,three,four,five,six,seven,eight,nine,ten,eleven,twelve,thirteen,fourteen,fifteen,sixteen");
       classes = classes.replace('column count', "one column,two column,three column,four column,five column,six column,seven column,eight column,nine column,ten column,eleven column,twelve column,thirteen column,fourteen column,fifteen column,sixteen column");
       classes = classes.replace('evenly divided', "one,two,three,four,five,six,seven,eight,nine,ten,eleven,twelve,thirteen,fourteen,fifteen,sixteen");

--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -290,7 +290,7 @@ semantic.ready = function() {
             }
           }
           if (wordOrder) {
-            $title.append(' <div class="ui small label"><i class="attention icon"></i>Word order required</div>');
+            $title.append(' <a href="/introduction/getting-started#class-order"><div class="ui small wordorder label"><i class="attention icon"></i>Word order required</div></a>');
           }
         })
       ;
@@ -806,8 +806,8 @@ semantic.ready = function() {
       }
       // Add common variations
       classes = classes.replace('text alignment', "left aligned, right aligned, justified, center aligned");
-      classes = classes.replace('floated', "right floated,left floated,floated");
-      classes = classes.replace('floating', "right floated,left floated,floated");
+      classes = classes.replace('floated', "!right floated,!left floated,floated");
+      classes = classes.replace('floating', "!right floated,!left floated,floated");
       classes = classes.replace('horizontally aligned', "left aligned, center aligned, right aligned, justified");
       classes = classes.replace('vertically aligned', "top aligned, middle aligned, bottom aligned");
       classes = classes.replace('vertically attached', "attached");
@@ -816,14 +816,14 @@ semantic.ready = function() {
       classes = classes.replace('relaxed', "very relaxed, relaxed");
       classes = classes.replace('attached', "left attached,right attached,top attached,bottom attached,attached");
       classes = classes.replace('thin', "very thin, thin");
-      classes = classes.replace('wide', "one wide,two wide,three wide,four wide,five wide,six wide,seven wide,eight wide,nine wide,ten wide,eleven wide,twelve wide,thirteen wide,fourteen wide,fifteen wide,sixteen wide,very wide,wide");
+      classes = classes.replace('wide', "!one wide,!two wide,!three wide,!four wide,!five wide,!six wide,!seven wide,!eight wide,!nine wide,!ten wide,!eleven wide,!twelve wide,!thirteen wide,!fourteen wide,!fifteen wide,!sixteen wide,!very wide,wide");
       classes = classes.replace('count', "one,two,three,four,five,six,seven,eight,nine,ten,eleven,twelve,thirteen,fourteen,fifteen,sixteen");
       classes = classes.replace('column count', "one column,two column,three column,four column,five column,six column,seven column,eight column,nine column,ten column,eleven column,twelve column,thirteen column,fourteen column,fifteen column,sixteen column");
       classes = classes.replace('evenly divided', "one,two,three,four,five,six,seven,eight,nine,ten,eleven,twelve,thirteen,fourteen,fifteen,sixteen");
       classes = classes.replace('size', "mini,tiny,small,medium,large,big,huge,massive");
       classes = classes.replace('position', "left,right,top,bottom");
       classes = classes.replace('emphasis', "primary,secondary,tertiary");
-      classes = classes.replace('colored', "primary,secondary,red,orange,yellow,olive,green,teal,blue,violet,purple,pink,brown,grey,black");
+      classes = classes.replace('colors', "primary,secondary,red,orange,yellow,olive,green,teal,blue,violet,purple,pink,brown,grey,black");
       classes = (classes !== '')
         ? classes.split(',')
         : []
@@ -896,9 +896,11 @@ semantic.ready = function() {
               : 0;
         });
         $.each(classes, function(index, string) {
+          html = newHTML || html;
           var
             className      = string.trim().replace('!',''),
             orderRequired  = string.trim()[0] === '!',
+            classReg       = new RegExp('<b.*?<\\/b>|(\\b' + className + '\\b)', 'g'),
             isClassMatch   = (html.search(className) !== -1)
           ;
           if(className === '') {
@@ -906,8 +908,9 @@ semantic.ready = function() {
           }
           // class match on current page element (or content if allowed)
           if(isClassMatch && (isPageElement || useContent) ) {
-            newHTML = html.replace(className, '<b data-position="bottom center" data-variation="mini '+(orderRequired ? 'red' : 'black')+'" data-tooltip="'+(orderRequired ? 'Word order r' : 'R')+'equired Class">' + className + '</b>');
-            return false;
+            newHTML = html.replace(classReg, function(match, group) {
+                return !group ? match : '<b data-position="right center" data-variation="mini" data-tooltip="'+(orderRequired ? 'Word order r' : 'R')+'equired Class">' + group + '</b>';
+            });
           }
         });
 

--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -265,10 +265,15 @@ semantic.ready = function() {
       $example
         .each(function() {
           var
-            $title   = $(this).children('h4').eq(0),
+            $example = $(this),
+            $title   = $example.children('h4').eq(0),
+            $firstP  = $example.children('p').eq(0),
             text     = handler.getText($title),
             safeName = handler.getSafeName(text),
-            id       = window.escape(safeName)
+            id       = window.escape(safeName),
+            since    = $example.data('since'),
+            classes  = $example.data('class'),
+            wordOrder = classes && classes.indexOf('!') >= 0
           ;
           if ($title.length > 0 && id.length > 0) {
             var $contentWrapped = $("<a/>").attr('href', '#' + id).html([
@@ -276,6 +281,16 @@ semantic.ready = function() {
               $title.html()
             ]).on('click', handler.scrollTo);
             $title.attr('id', id).html($contentWrapped);
+          }
+          if (since) {
+            if ($title.length > 0) {
+              $title.append(' <div class="ui teal label">New in ' + since + '</div>');
+            } else if ($firstP.length > 0) {
+                $firstP.append(' <span class="ui teal label">New in ' + since + '</span>');
+            }
+          }
+          if (wordOrder) {
+            $title.append(' <div class="ui small label"><i class="attention icon"></i>Word order required</div>');
           }
         })
       ;
@@ -870,9 +885,20 @@ semantic.ready = function() {
         isOtherUI     = (!isPageElement && isUI);
         isOtherIcon   = (!isPageElement && tagHTML === 'i' && html.search('icon') !== -1);
         // check if any class match
+        // check multi-word classes first
+        classes.sort(function(a,b){
+          var aSpaces = a.split(' ').length - 1,
+              bSpaces = b.split(' ').length - 1;
+          return aSpaces > bSpaces
+            ? -1
+            : aSpaces < bSpaces
+              ? 1
+              : 0;
+        });
         $.each(classes, function(index, string) {
           var
-            className      = string.trim(),
+            className      = string.trim().replace('!',''),
+            orderRequired  = string.trim()[0] === '!',
             isClassMatch   = (html.search(className) !== -1)
           ;
           if(className === '') {
@@ -880,7 +906,7 @@ semantic.ready = function() {
           }
           // class match on current page element (or content if allowed)
           if(isClassMatch && (isPageElement || useContent) ) {
-            newHTML = html.replace(className, '<b title="Required Class">' + className + '</b>');
+            newHTML = html.replace(className, '<b data-position="bottom center" data-variation="mini '+(orderRequired ? 'red' : 'black')+'" data-tooltip="'+(orderRequired ? 'Word order r' : 'R')+'equired Class">' + className + '</b>');
             return false;
           }
         });

--- a/server/files/javascript/search.js
+++ b/server/files/javascript/search.js
@@ -283,7 +283,8 @@ semantic.search.ready = function() {
   $local
     .search({
       searchFields: ['title'],
-      source: content
+      source: content,
+      maxResults: 20
     })
   ;
 

--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -58,7 +58,7 @@ pre {
 pre.console {
   background-color: transparent;
   line-height: 1.6;
-  font-family:  'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+  font-family:  "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
   height: 300px;
   overflow: auto;
   direction:ltr;
@@ -111,14 +111,14 @@ blockquote .author {
 
 /* Replace Code Icon */
 @font-face {
-  font-family: 'Docs Code';
-  src: url(data:application/font-woff;base64,d09GRgABAAAAAAPgAA0AAAAABfAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAADxAAAABwAAAAcjlprJ0dERUYAAAOoAAAAHAAAACAAJwAYT1MvMgAAAZgAAABCAAAAYE2nTH1jbWFwAAAB8AAAAFMAAAFgIW3M02dhc3AAAAOgAAAACAAAAAgAAAAQZ2x5ZgAAAlQAAABEAAAAbFsDJYNoZWFkAAABMAAAADIAAAA2EOu+a2hoZWEAAAFkAAAAGwAAACQDogGnaG10eAAAAdwAAAAUAAAAGANqAABsb2NhAAACRAAAAA4AAAAOAE4AIG1heHAAAAGAAAAAFwAAACAACQAQbmFtZQAAApgAAADfAAABtq0mwDNwb3N0AAADeAAAACgAAABG3t27+nicY2BkYGAA4m3nl/LF89t8ZeBmYgCBC2uFdoLo+wnZpiCa8QBjA5DiYABLAwAfbAlaAAB4nGNgZGBgfPD/AZA8wMAAJhkZUAEbAHQOBEsAeJxjYGRgYGBj4GNgYgABCIkEAAKPABoAeJxjYGZMYJzAwMrAwOjDmMbAwOAOpb8ySDK0MKACRgEkTkCaawqDAwPDMwbGB/8fACUfMCiA1CApUWBgBAAC5Aq1AAB4nGNggIJVEIoRhA8wMAAADFoBbXic3Y3RCYBADENfz1MORxA/nMRBnF9uC6lpBcEVTEmTQGiBgYcrRuBQssyVXTrTKBpj6/jlnq3X+7mMyqZeoKWPe9gkppMWrcIX+lL5N25EKQ0lAAAAAAAACAAIABAAGAA2AAB4nGNgZIABJgYGSyYGQnwgyeDAeICxgYGNgZeBgZFdnF3cXF0ZRJirMxoYFBQYTJiwYMIEEIOxAUQuAAIQzQAAbj8O/Hicdc0xCsJAFATQSYyKCiIIFtpsLwRFbyAIIjYWNlYxLkFIdmGNhXgAj2DpbbyB93GSfMsEEt6f3fkBMMAHHv6PL/bQxlDs01Nxg16JA/oobqKHh7jF/CXuYowvW17QkT9U9tCnKvv0RNygF+KA3oqbGCEWt5g/xV0s8S7WXnhskfG1MBxjm1lL7KGR4IYUERxHndzSyNXfr8sP3ONw5XmRK8wRYsZYu+vFGjUPZ/XddTnnbCXcYspNEWeNM7MT7vxuyu5OuiFL1uQq0Ua7KNdndbqrTWx33BfiB651PpsAeJxjYGLAD9gYGBiZGJgYmRmYGVnYS/MyDYAAShuCaFczAwMAU48GbwABAAH//wAPeJxjYGRgYOABYgEGCQYmIM0CxCCaEYIBBW0AQAAAAAEAAAAA3kztOAAAAADQrRK5AAAAAN9gazU=) format('woff');
+  font-family: "Docs Code";
+  src: url(data:application/font-woff;base64,d09GRgABAAAAAAPgAA0AAAAABfAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAADxAAAABwAAAAcjlprJ0dERUYAAAOoAAAAHAAAACAAJwAYT1MvMgAAAZgAAABCAAAAYE2nTH1jbWFwAAAB8AAAAFMAAAFgIW3M02dhc3AAAAOgAAAACAAAAAgAAAAQZ2x5ZgAAAlQAAABEAAAAbFsDJYNoZWFkAAABMAAAADIAAAA2EOu+a2hoZWEAAAFkAAAAGwAAACQDogGnaG10eAAAAdwAAAAUAAAAGANqAABsb2NhAAACRAAAAA4AAAAOAE4AIG1heHAAAAGAAAAAFwAAACAACQAQbmFtZQAAApgAAADfAAABtq0mwDNwb3N0AAADeAAAACgAAABG3t27+nicY2BkYGAA4m3nl/LF89t8ZeBmYgCBC2uFdoLo+wnZpiCa8QBjA5DiYABLAwAfbAlaAAB4nGNgZGBgfPD/AZA8wMAAJhkZUAEbAHQOBEsAeJxjYGRgYGBj4GNgYgABCIkEAAKPABoAeJxjYGZMYJzAwMrAwOjDmMbAwOAOpb8ySDK0MKACRgEkTkCaawqDAwPDMwbGB/8fACUfMCiA1CApUWBgBAAC5Aq1AAB4nGNggIJVEIoRhA8wMAAADFoBbXic3Y3RCYBADENfz1MORxA/nMRBnF9uC6lpBcEVTEmTQGiBgYcrRuBQssyVXTrTKBpj6/jlnq3X+7mMyqZeoKWPe9gkppMWrcIX+lL5N25EKQ0lAAAAAAAACAAIABAAGAA2AAB4nGNgZIABJgYGSyYGQnwgyeDAeICxgYGNgZeBgZFdnF3cXF0ZRJirMxoYFBQYTJiwYMIEEIOxAUQuAAIQzQAAbj8O/Hicdc0xCsJAFATQSYyKCiIIFtpsLwRFbyAIIjYWNlYxLkFIdmGNhXgAj2DpbbyB93GSfMsEEt6f3fkBMMAHHv6PL/bQxlDs01Nxg16JA/oobqKHh7jF/CXuYowvW17QkT9U9tCnKvv0RNygF+KA3oqbGCEWt5g/xV0s8S7WXnhskfG1MBxjm1lL7KGR4IYUERxHndzSyNXfr8sP3ONw5XmRK8wRYsZYu+vFGjUPZ/XddTnnbCXcYspNEWeNM7MT7vxuyu5OuiFL1uQq0Ua7KNdndbqrTWx33BfiB651PpsAeJxjYGLAD9gYGBiZGJgYmRmYGVnYS/MyDYAAShuCaFczAwMAU48GbwABAAH//wAPeJxjYGRgYOABYgEGCQYmIM0CxCCaEYIBBW0AQAAAAAEAAAAA3kztOAAAAADQrRK5AAAAAN9gazU=) format("woff");
   font-weight: normal;
   font-style: normal;
 }
 
 #example .example i.fitted.code.icon:before {
-  font-family: 'Docs Code';
+  font-family: "Docs Code";
   content: "\e600";
   vertical-align: top;
 }
@@ -474,7 +474,7 @@ blockquote .author {
   width: 100%;
   height: 1px;
   background-color: #4183C4;
-  content: '';
+  content: "";
   -webkit-backface-visibility: hidden;
   transition: all 0.2s;
   backface-visibility: hidden;
@@ -584,7 +584,7 @@ blockquote .author {
   font-weight: normal;
   transform: rotateZ(0deg);
   -ms-transform: none !important;
-  font-family:  'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+  font-family:  "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
 }
 
 #example table .instructive.segment {
@@ -780,7 +780,7 @@ blockquote .author {
   z-index: 1;
 }
 #example .main.container:after {
-  content: '';
+  content: "";
   display: block;
   height: 0;
   clear: both;
@@ -870,7 +870,7 @@ blockquote .author {
 }
 
 /*#example .example i.code:before {*/
-/*font-family: 'Docs';*/
+/*font-family: "Docs";*/
 /*content: "\e600";*/
 /*}*/
 #example .example:hover i.code {
@@ -934,7 +934,7 @@ blockquote .author {
   padding: 1.15em 1em 1em;
 }
 #example .example > .html.segment:after {
-  content: '';
+  content: "";
   display: block;
   height: 0;
   clear: both;
@@ -1056,7 +1056,7 @@ blockquote .author {
   top: 1rem;
   left: 1rem;
   background-color: #FAFAFA;
-  content: '';
+  content: "";
   width: calc(100% - 2rem);
   height: calc(100% - 2rem);
   box-shadow: 0 0 0 1px #DDDDDD inset;

--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -637,8 +637,9 @@ blockquote .author {
 /* Header */
 #example .example > h4:first-child {
   font-size: 18px;
-  margin: 0 0 0;
+  margin: -2em 0 0;
   position: relative;
+  padding-top: 2em;
 }
 
 #example .example > h4 > a {
@@ -1695,7 +1696,6 @@ code.code .class {
 }
 code.code .class b {
   font-weight: normal;
-  background-color: rgba(90, 90, 90, 0);
   border-radius: 5px;
   line-height: 1;
   vertical-align: baseline;
@@ -1703,19 +1703,38 @@ code.code .class b {
   transition: all 0.3s ease;
   margin: 0 -4px;
   padding: 1px 4px;
-}
-code.code .class b {
-  background-color: rgba(218, 189, 40, 0.15);
+  background-color: rgba(248, 219, 70, 0.35);
   color: #9E6C00;
 }
 
-/*
-code.code:hover .class.string b,
-code.code:hover .class.value b {
-  background-color: rgba(218, 189, 40, 0.1);
-  color: inherit;
+code.code .class b::after,
+code.code .class b::before,
+code.code .class b:hover {
+  background-color: rgba(248, 219, 70, 1);
 }
-*/
+
+code.code .class b::after {
+  padding-top: 0.1em;
+  padding-bottom: 0.1em;
+  border: 1px solid #bababc;
+}
+
+.ui.wordorder.label,
+code.code .class b[data-tooltip~="order"] {
+  background-color: rgba(255, 220, 220, 0.4);
+  color: #9F3A38;
+}
+code.code .class b[data-tooltip~="order"]::after,
+code.code .class b[data-tooltip~="order"]::before,
+code.code .class b[data-tooltip~="order"]:hover {
+  background-color: rgba(255, 220, 220, 1);
+}
+
+@supports selector(:has(.f)) {
+  #example .example:has(> .segment > pre > code.code) {
+    margin-top: -1em;
+  }
+}
 
 
 /* Linked UI */

--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -1711,6 +1711,7 @@ code.code .class b::after,
 code.code .class b::before,
 code.code .class b:hover {
   background-color: rgba(248, 219, 70, 1);
+  color: #7E4C00;
 }
 
 code.code .class b::after {

--- a/server/files/stylesheets/home.css
+++ b/server/files/stylesheets/home.css
@@ -57,7 +57,7 @@
   z-index: -1;
   width: 100%;
   height: 100%;
-  content: '';
+  content: "";
   background-size: cover;
 
   opacity: 0.45;

--- a/server/layouts/default.html.eco
+++ b/server/layouts/default.html.eco
@@ -18,7 +18,7 @@
   <div class="pusher">
     <div class="full height">
       <div class="toc">
-        <div class="ui vertical inverted menu">
+        <div class="ui big vertical inverted menu">
           <%- @partial('site-menu') %>
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR stronlgy improves #446 and 
- implements automatic  header label creation for "New in..." via data-attribute
  - also unifies the label color now
- implements automatic header label for required word order via data-attribute
  - links to a central description on label click why word order is sometimes necessary
- added lots of missing highlight words in data-class
- adjusted lots of highlight class logic when no h4 header or "another example" or "without ui" was used 
- enhances source code display 
  - highlight required classes
  - highlight word order classes in different color
  - support multiple classes inside one class definition
 
## Screenshots
![image](https://user-images.githubusercontent.com/18379884/227013505-655ca05d-29fc-4f92-96f7-5975a1112f1c.png)
![requiredorderclasseshighlight](https://user-images.githubusercontent.com/18379884/227013691-9109d557-c34b-48d5-8d74-a3411ae9bae2.gif)

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/2494#issuecomment-118257133
https://github.com/fomantic/Fomantic-UI/issues/2738#issuecomment-1472448448