### PR TITLE
feat(dropdown): keepsearchterm example

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -308,12 +308,25 @@ themes      : ['Default', 'GitHub', 'Material']
         <%- @partial('examples/single/skill-menu') %>
       </select>
     </div>
-    <div class="dropdown example">
+    <div class="dropdown example" data-class="search">
       <h4 class="ui header">Multiple Search Selection</h4>
       <p>A selection dropdown can allow multiple search selections</p>
       <select class="ui fluid search dropdown" multiple>
         <%- @partial('examples/single/state-options') %>
       </select>
+    </div>
+    <div class="keepsearchterm example" data-since="2.9.3" data-class="multiple search selection">
+      <p>A multiple search selection dropdown can keep its search value on item selection so the menu stays filtered</p>
+      <select class="ui fluid multiple search selection dropdown">
+        <%- @partial('examples/single/state-options') %>
+      </select>
+      <div class="code">
+          $('.ui.search.selection.dropdown')
+            .dropdown({
+              keepSearchTerm: true
+            })
+          ;
+      </div>
     </div>
     <div class="another dropdown example">
       <div class="ui ignored info message">
@@ -3458,6 +3471,11 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>Whether search selection will force currently selected choice when element is blurred.<br>If a <code>select</code> tag with a <code>required</code> attribute was used, the forceSelection setting will be set to true automatically</td>
         </tr>
         <tr>
+          <td>keepSearchTerm</td>
+          <td>false</td>
+          <td>Whether the search value should be kept and menu stays filtered on item selection.</td>
+        </tr>
+        <tr>
           <td>allowCategorySelection</td>
           <td>false</td>
           <td>Whether menu items with sub-menus (categories) should be selectable</td>
@@ -3597,13 +3615,6 @@ themes      : ['Default', 'GitHub', 'Material']
            false
           </td>
           <td>When set to a number, sets the maximum number of selections</td>
-        </tr>
-        <tr>
-          <td>glyphWidth</td>
-          <td>
-           1.037
-          </td>
-          <td>Maximum glyph width, used to calculate search size. This is usually size of a "W" in your font in <code>em</code></td>
         </tr>
         <tr>
           <td>headerDivider</td>

--- a/server/files/javascript/dropdown.js
+++ b/server/files/javascript/dropdown.js
@@ -10,6 +10,7 @@ semantic.dropdown.ready = function() {
     $clearingDropdown = $examples.filter('.clearing').find('.ui.dropdown'),
     $buttonDropdown   = $examples.filter('.button.example').find('.ui.dropdown'),
     $dropdown         = $examples.filter('.dropdown').find('.menu > .item > .ui.dropdown, .menu > .item.ui.dropdown, > .ui.dropdown:not(.simple):not(.selection), .inline.dropdown, .icon.buttons .button, .form .dropdown.selection'),
+    $keepSearchTerm   = $examples.filter('.keepsearchterm').find(' > .ui.selection.dropdown'),
     $selectionDropdown= $examples.filter('.dropdown').find(' > .ui.selection.dropdown'),
     $transition       = $examples.filter('.transition').find('.ui.dropdown'),
     $simpleDropdown   = $examples.filter('.simple').find('.ui.dropdown'),
@@ -58,6 +59,14 @@ semantic.dropdown.ready = function() {
   ;
   $selectionDropdown
     .dropdown({
+        className: {
+            menu: 'scrollhint menu'
+        }
+    })
+  ;
+  $keepSearchTerm
+    .dropdown({
+        keepSearchTerm: true,
         className: {
             menu: 'scrollhint menu'
         }


### PR DESCRIPTION
## Description
Added `keepSearchTerm` example and removed unused glyphWidth setting as of https://github.com/fomantic/Fomantic-UI/pull/2743

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/227482304-0ea6b549-f997-4302-8ac2-66b2b1e32fcc.png)
![image](https://user-images.githubusercontent.com/18379884/227482369-1b3419b4-044f-40b2-acac-a6422707c153.png)
