### PR TITLE
feat(multiple): resizable info, scrolling content missing and typo fixes

### DIFF
--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -2156,6 +2156,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
         Some table variants like <a href="#column-width">column width</a> or <a href="#single-line">single line</a> do not work with a scrolling table.
         If you need such combinations use a <a href="#stuck">stuck table</a> instead.
     </div>
+    <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the table body. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
     <table class="ui unstackable celled scrolling table">
     <thead>
       <tr>

--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -2156,7 +2156,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
         Some table variants like <a href="#column-width">column width</a> or <a href="#single-line">single line</a> do not work with a scrolling table.
         If you need such combinations use a <a href="#stuck">stuck table</a> instead.
     </div>
-    <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the table body. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
+    <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the table body. This needs a <a href="https://caniuse.com/?search=resize" target="_blank">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
     <table class="ui unstackable celled scrolling table">
     <thead>
       <tr>
@@ -2387,7 +2387,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     If you don't want to have an extra wrapper, you can use <code>overflowing stuck table</code>. However, this only works if your overall table columns exceed available width.
     </div>
     <div class="ui ignored warning message">
-        A stuck table needs a modern browser with <a href="https://caniuse.com/?search=position%20sticky">position:sticky support</a>, so does not work in IE11 or legacy Edge
+        A stuck table needs a modern browser with <a href="https://caniuse.com/?search=position%20sticky" target="_blank">position:sticky support</a>, so does not work in IE11 or legacy Edge
     </div>
     <div class="ui short scrolling container">
       <table class="ui first last head foot stuck unstackable celled table">

--- a/server/documents/elements/container.html.eco
+++ b/server/documents/elements/container.html.eco
@@ -294,6 +294,7 @@ themes      : ['Default']
   <div class="example" data-since="2.9" data-class="!very short, !very long">
     <h4 class="ui header">Scrolling</h4>
     <p>A scrolling container has a predefined height to allow its content to be scrollable</p>
+    <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the container. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
     <div class="ui scrolling container">
       <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
       <p>Te eum doming eirmod, nominati pertinacia argumentum ad his. Ex eam alia facete scriptorem, est autem aliquip detraxit at. Usu ocurreret referrentur at, cu epicurei appellantur vix. Cum ea laoreet recteque electram, eos choro alterum definiebas in. Vim dolorum definiebas an. Mei ex natum rebum iisque.</p>

--- a/server/documents/elements/container.html.eco
+++ b/server/documents/elements/container.html.eco
@@ -294,7 +294,7 @@ themes      : ['Default']
   <div class="example" data-since="2.9" data-class="!very short, !very long">
     <h4 class="ui header">Scrolling</h4>
     <p>A scrolling container has a predefined height to allow its content to be scrollable</p>
-    <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the container. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
+    <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the container. This needs a <a href="https://caniuse.com/?search=resize" target="_blank">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
     <div class="ui scrolling container">
       <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
       <p>Te eum doming eirmod, nominati pertinacia argumentum ad his. Ex eam alia facete scriptorem, est autem aliquip detraxit at. Usu ocurreret referrentur at, cu epicurei appellantur vix. Cum ea laoreet recteque electram, eos choro alterum definiebas in. Vim dolorum definiebas an. Mei ex natum rebum iisque.</p>

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -652,7 +652,7 @@ themes      : ['default', 'GitHub']
   <div class="example" data-since="2.9" data-class="!very short, !very long, short, long">
     <h4 class="ui header">Scrolling</h4>
     <p>A scrolling segment has a predefined height to allow its content to be scrollable</p>
-    <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the segment. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
+    <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the segment. This needs a <a href="https://caniuse.com/?search=resize" target="_blank">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
     <div class="ui scrolling segment">
       <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
       <p>Te eum doming eirmod, nominati pertinacia argumentum ad his. Ex eam alia facete scriptorem, est autem aliquip detraxit at. Usu ocurreret referrentur at, cu epicurei appellantur vix. Cum ea laoreet recteque electram, eos choro alterum definiebas in. Vim dolorum definiebas an. Mei ex natum rebum iisque.</p>

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -652,6 +652,7 @@ themes      : ['default', 'GitHub']
   <div class="example" data-since="2.9" data-class="!very short, !very long, short, long">
     <h4 class="ui header">Scrolling</h4>
     <p>A scrolling segment has a predefined height to allow its content to be scrollable</p>
+    <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the segment. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
     <div class="ui scrolling segment">
       <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
       <p>Te eum doming eirmod, nominati pertinacia argumentum ad his. Ex eam alia facete scriptorem, est autem aliquip detraxit at. Usu ocurreret referrentur at, cu epicurei appellantur vix. Cum ea laoreet recteque electram, eos choro alterum definiebas in. Vim dolorum definiebas an. Mei ex natum rebum iisque.</p>

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -1319,7 +1319,7 @@ themes      : ['Default', 'GitHub', 'Material']
      <div class="ui ignored warning message">
         Scrolling dropdowns are incompatible with the usage of <code>sub menu</code>.
       </div>
-      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the menu. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
+      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the menu. This needs a <a href="https://caniuse.com/?search=resize" target="_blank">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
       <div class="ui scrolling dropdown">
         <input type="hidden" name="gender">
         <div class="default text">Select choice</div>
@@ -1747,7 +1747,7 @@ themes      : ['Default', 'GitHub', 'Material']
       <p>You can stick this addition line to the top of the menu by providing the additional <code>stuck</code> class.</p>
 
       <div class="ui ignored warning message">
-        A stuck user additions dropdown needs a modern browser with <a href="https://caniuse.com/?search=position%20sticky">position:sticky support</a>, so does not work in IE11 or legacy Edge
+        A stuck user additions dropdown needs a modern browser with <a href="https://caniuse.com/?search=position%20sticky" target="_blank">position:sticky support</a>, so does not work in IE11 or legacy Edge
       </div>
 
       <div class="ui sub header">Single</div>

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -1316,9 +1316,10 @@ themes      : ['Default', 'GitHub', 'Material']
     <div class="dropdown example">
       <h4 class="ui header">Scrolling</h4>
       <p>A dropdown can have its menu scroll</p>
-      <div class="ui ignored warning message">
+     <div class="ui ignored warning message">
         Scrolling dropdowns are incompatible with the usage of <code>sub menu</code>.
       </div>
+      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the menu. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
       <div class="ui scrolling dropdown">
         <input type="hidden" name="gender">
         <div class="default text">Select choice</div>

--- a/server/documents/modules/flyout.html.eco
+++ b/server/documents/modules/flyout.html.eco
@@ -19,6 +19,32 @@ themes      : ['Default']
 <%- @partial('header', { tabs: 'module' }) %>
 <div class="main ui container">
 
+  <div class="ui longer test flyout">
+    <div class="ui header">Flyout Header</div>
+    <div class="scrolling content">
+        <p>This is an example of expanded content that will cause the flyout's content to scroll</p>
+        <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
+        <div class="ui divider"></div>
+        <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
+        <div class="ui divider"></div>
+        <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
+        <div class="ui divider"></div>
+        <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
+        <div class="ui divider"></div>
+        <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
+        <div class="ui divider"></div>
+        <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
+        <div class="ui divider"></div>
+        <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
+    </div>
+    <div class="actions">
+      <div class="ui primary approve button">
+        Proceed
+        <i class="right chevron icon"></i>
+      </div>
+    </div>
+  </div>
+
   <div class="ui active tab" data-tab="definition">
 
     <h2 class="ui dividing header">Types</h2>
@@ -106,7 +132,7 @@ themes      : ['Default']
       </div>
     </div>
 
-    <div class="example">
+    <div class="no example">
       <h4 class="ui header">Fullscreen</h4>
       <p>A flyout can take all the entire screen if needed.</p>
       <div class="code" data-demo="true" data-type="javascript" data-eval="$('.fullscreen.flyout').flyout('toggle');">
@@ -115,6 +141,26 @@ themes      : ['Default']
         ;
       </div>
 
+    </div>
+
+    <div class="no example" data-use-content="true">
+      <h4 class="ui header">
+        Scrolling Content
+      </h4>
+      <p>A flyout can have a scrolling content</p>
+      <div class="code" data-type="html" data-variation="scrolling">
+        <div class="ui flyout">
+          <div class="header">Header</div>
+          <div class="scrolling content">
+            <p>Very long content goes here</p>
+          </div>
+        </div>
+      </div>
+      <div class="code" data-demo="true">
+      $('.ui.longer.flyout')
+        .flyout('show')
+      ;
+      </div>
     </div>
 
     <div class="no example" data-use-content="true">

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -640,7 +640,7 @@ themes      : ['Default', 'Material']
         Scrolling Content
       </h4>
       <p>A modal can have a scrolling content</p>
-      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling content</code> and a native resize drag handler will appear to the bottom right of the content. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
+      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling content</code> and a native resize drag handler will appear to the bottom right of the content. This needs a <a href="https://caniuse.com/?search=resize" target="_blank">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
       <div class="code" data-type="html" data-variation="scrolling">
         <div class="ui modal">
           <div class="header">Header</div>
@@ -786,7 +786,7 @@ themes      : ['Default', 'Material']
     <div class="no example">
       <h4 class="ui header">Internally Scrolling Content</h4>
       <p>You may prefer to have the content of your modal scroll itself, you can do this by using the <code>scrolling content</code> variation.</p>
-      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling content</code> and a native resize drag handler will appear to the bottom right of the content. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
+      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling content</code> and a native resize drag handler will appear to the bottom right of the content. This needs a <a href="https://caniuse.com/?search=resize" target="_blank">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
       <div class="code" data-demo="true">
       $('.longer.modal')
         .modal('show')

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -261,7 +261,7 @@ themes      : ['Default', 'Material']
       </div>
       <div class="description">
         <div class="ui header">Modal Header</div>
-        <p>This is an example of expanded content that will cause the modal's dimmer to scroll</p>
+        <p>This is an example of expanded content that will cause the modal's content to scroll</p>
         <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
         <div class="ui divider"></div>
         <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
@@ -639,7 +639,8 @@ themes      : ['Default', 'Material']
       <h4 class="ui header">
         Scrolling Content
       </h4>
-      <p>A modal can use the entire size of the screen</p>
+      <p>A modal can have a scrolling content</p>
+      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling content</code> and a native resize drag handler will appear to the bottom right of the content. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
       <div class="code" data-type="html" data-variation="scrolling">
         <div class="ui modal">
           <div class="header">Header</div>
@@ -785,6 +786,7 @@ themes      : ['Default', 'Material']
     <div class="no example">
       <h4 class="ui header">Internally Scrolling Content</h4>
       <p>You may prefer to have the content of your modal scroll itself, you can do this by using the <code>scrolling content</code> variation.</p>
+      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling content</code> and a native resize drag handler will appear to the bottom right of the content. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
       <div class="code" data-demo="true">
       $('.longer.modal')
         .modal('show')

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -304,7 +304,7 @@ type        : 'UI Module'
 	  <div class="ui ignored info message">
         <p>The search scroll height depends on viewport size. The search scroll height is calculated using <strong>search item height * number of items</strong> to be shown for applicable media query break point.</p>
       </div>
-      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the results. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
+      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the results. This needs a <a href="https://caniuse.com/?search=resize" target="_blank">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
       <div class="ui scrolling local search">
         <div class="ui icon input">
           <input class="prompt" type="text" placeholder="Search countries...">

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -304,6 +304,7 @@ type        : 'UI Module'
 	  <div class="ui ignored info message">
         <p>The search scroll height depends on viewport size. The search scroll height is calculated using <strong>search item height * number of items</strong> to be shown for applicable media query break point.</p>
       </div>
+      <div class="ui ignored message" data-since="2.9.3">You can also use <code>resizable scrolling</code> and a native resize drag handler will appear to the bottom right of the results. This needs a <a href="https://caniuse.com/?search=resize">modern browser</a>, so does not work in IE11 or legacy Edge.</div>
       <div class="ui scrolling local search">
         <div class="ui icon input">
           <input class="prompt" type="text" placeholder="Search countries...">


### PR DESCRIPTION
## Description
- added resizable infos as of https://github.com/fomantic/Fomantic-UI/pull/2748
- added missing scrolling content example for flyout
- fixed some typos

## Screenshots
![image](https://user-images.githubusercontent.com/18379884/229489002-38475620-423b-4ced-9884-3d8edf54ae83.png)
![image](https://user-images.githubusercontent.com/18379884/229489154-f623e4eb-31d5-4095-8075-0d0586a32037.png)
