### PR TITLE
feat(form): native browser validation example

### DIFF
--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -344,6 +344,33 @@ type        : 'UI Behavior'
       </div>
     </div>
 
+    <div class="native example" data-since="2.9.3">
+      <h4 class="ui header">Native Browser Validation</h4>
+      <p>You can also make use of the <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#using_built-in_form_validation">native browser built-in form validation</a> without the need to specify rules. You can still provide rules in addition, but you could also completely rely on native validation.</p>
+      <div class="ignored code">
+      $('.ui.form')
+        .form({
+            inline: true
+        })
+      ;
+      </div>
+      <form class="ui form segment">
+        <div class="field">
+          <label>Number</label>
+          <input type="number" name="number" min="1" max="10" placeholder="Anything between 1 and 10" required>
+        </div>
+        <div class="field">
+          <label>Url</label>
+          <input type="url" name="url" placeholder="A valid url needed" required>
+        </div>
+        <div class="field">
+          <label>File</label>
+          <input type="file" name="file" placeholder="A valid url needed" required>
+        </div>
+        <div class="ui primary submit button">Submit</div>
+        </form>
+    </div>
+
     <h2 class="ui dividing header">Rules</h2>
 
     <div class="no example">

--- a/server/files/javascript/validate-form.js
+++ b/server/files/javascript/validate-form.js
@@ -11,6 +11,7 @@ semantic.validateForm.ready = function() {
     $autoForm     = $('.auto.example .ui.form'),
     $colorForm    = $('.color.example .ui.form'),
     $promptForm   = $('.prompt.example .ui.form'),
+    $nativeForm   = $('.native.example .ui.form'),
     $ruleForm     = $('.custom.rule.example .ui.form'),
     $dropdownForm = $('.dropdown.example .ui.form'),
     $optionalForm = $('.optional.example .ui.form'),
@@ -235,6 +236,9 @@ semantic.validateForm.ready = function() {
     }
   });
 
+  $nativeForm.form({
+    inline: true
+  });
 
   $promptForm
     .form({


### PR DESCRIPTION
## Description
Added an example to only use native browser validation as of https://github.com/fomantic/Fomantic-UI/pull/2751

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/229500501-c54392b2-a112-48ca-b783-9d5a0b5a6df6.png)
