### PR TITLE
fix(dropdown): enable codeview for text label example

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -1778,7 +1778,7 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
-    <div class="no label example">
+    <div class="label example">
       <h4 class="ui header">Text Labels</h4>
       <p>Sometimes multiselect include options which are long and would appear awkwardly as labels. Setting <code>useLabels: false</code> will display a selected count, and allow reselection directly from the menu.</p>
       <div class="ui ignored info message">
@@ -1802,7 +1802,7 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
 
       <div class="evaluated code" data-type="javascript">
-        $('.no.label.example .ui.dropdown')
+        $('.label.example .ui.dropdown')
           .dropdown({
             useLabels: false
           })


### PR DESCRIPTION
## Description

The "text label" example had the code view icon disabled

@ihorvyshniakov This fixes your SUI issue (i cannot comment there)

## Screenshot
![image](https://user-images.githubusercontent.com/18379884/233124136-4ebe1eb7-ad82-4478-8125-97812e3e1d25.png)


## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/7114
