### PR TITLE
fix(chore): dont linkify existing links in headers

### DIFF
--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -283,7 +283,7 @@ semantic.ready = function() {
             classes  = $example.data('class'),
             wordOrder = classes && classes.indexOf('!') >= 0
           ;
-          if ($title.length > 0 && id.length > 0) {
+          if ($title.length > 0 && id.length > 0 && $title.find('a').length === 0) {
             var $contentWrapped = $("<a/>").attr('href', '#' + id).html([
               $('<i class="fitted small linkify icon"></i>'),
               $title.html()

--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -642,10 +642,10 @@ blockquote .author {
   padding-top: 2em;
 }
 
-#example .example > h4 > a {
+#example .example > h4 > a[href^="#"] {
   color: rgba(0, 0, 0, 0.87);
 }
-#example .example > h4 > a:hover {
+#example .example > h4 > a[href^="#"]:hover {
   color: rgba(0, 0, 0, 0.95);
 }
 #example .example > h4 > a > i.linkify.icon {


### PR DESCRIPTION
## Description
In case a Heading inside examples already got a link, the automatic anchor link wrapper would eliminate the functionality of the existing link. This happens on the homepage examples where the Headings are supposed to link to the related component website but instead a click on them does nothing as the wrapped anchor link prevents that.
So, the linkify anchor generation should only happen when the heading does not already contain a link, which this PR fixes