### PR TITLE
feat(form): notempty rule and deprecation labeling

### DIFF
--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -33,11 +33,11 @@ type        : 'UI Behavior'
       $('.ui.form')
         .form({
           fields: {
-            name     : 'empty',
-            gender   : 'empty',
-            username : 'empty',
-            password : ['minLength[6]', 'empty'],
-            skills   : ['minCount[2]', 'empty'],
+            name     : 'notEmpty',
+            gender   : 'notEmpty',
+            username : 'notEmpty',
+            password : ['minLength[6]', 'notEmpty'],
+            skills   : ['minCount[2]', 'notEmpty'],
             terms    : 'checked'
           }
         })
@@ -52,7 +52,7 @@ type        : 'UI Behavior'
               identifier: 'name',
               rules: [
                 {
-                  type   : 'empty',
+                  type   : 'notEmpty',
                   prompt : 'Please enter your name'
                 }
               ]
@@ -70,7 +70,7 @@ type        : 'UI Behavior'
               identifier: 'gender',
               rules: [
                 {
-                  type   : 'empty',
+                  type   : 'notEmpty',
                   prompt : 'Please select a gender'
                 }
               ]
@@ -79,7 +79,7 @@ type        : 'UI Behavior'
               identifier: 'username',
               rules: [
                 {
-                  type   : 'empty',
+                  type   : 'notEmpty',
                   prompt : 'Please enter a username'
                 }
               ]
@@ -89,7 +89,7 @@ type        : 'UI Behavior'
               errorLimit: 1,
               rules: [
                 {
-                  type   : 'empty',
+                  type   : 'notEmpty',
                   prompt : 'Please enter a password'
                 },
                 {
@@ -219,7 +219,7 @@ type        : 'UI Behavior'
             field1: {
               rules: [
                 {
-                  type   : 'empty'
+                  type   : 'notEmpty'
                 }
               ]
             },
@@ -281,7 +281,7 @@ type        : 'UI Behavior'
               identifier : 'special-name',
               rules: [
                 {
-                  type   : 'empty'
+                  type   : 'notEmpty'
                 }
               ]
             }
@@ -331,8 +331,8 @@ type        : 'UI Behavior'
       $('.ui.form')
         .form({
           fields: {
-           email: 'empty',
-           name: 'empty'
+           email: 'notEmpty',
+           name: 'notEmpty'
           }
         })
       ;
@@ -383,12 +383,16 @@ type        : 'UI Behavior'
       <div class="ui info message">To pass parameters to a rule, use bracket notation in your settings object. For example <code>type: 'not[dog]'</code></div>
       <div data-since="2.8.8" class="ui info message">Despite the global setting <code>shouldTrim</code> you can optionally specify to trim/not trim values before validation by adding <code>shouldTrim:true</code> or <code>shouldTrim:false</code> to each rule</div>
 
-      <h3 class="ui header"><a href="#empty">Empty</a></h3>
+      <h3 class="ui header"><a href="#notempty">Not Empty</a></h3>
       <table class="ui celled sortable basic table segment">
         <tbody>
           <tr>
-            <td class="four wide">empty</td>
-            <td class="twelve wide">A field is empty</td>
+            <td class="four wide">notEmpty</td>
+            <td class="twelve wide">A field is not empty</td>
+          </tr>
+          <tr data-deprecated="[2.9.4]Use 'notEmpty' instead">
+            <td>empty</td>
+            <td>A field is not empty</td>
           </tr>
           <tr>
             <td>checked</td>
@@ -904,7 +908,7 @@ type        : 'UI Behavior'
                 identifier  : 'empty',
                 rules: [
                   {
-                    type   : 'empty',
+                    type   : 'notEmpty',
                     prompt : 'Please enter a value'
                   }
                 ]
@@ -913,7 +917,7 @@ type        : 'UI Behavior'
                 identifier  : 'dropdown',
                 rules: [
                   {
-                    type   : 'empty',
+                    type   : 'notEmpty',
                     prompt : 'Please select a dropdown value'
                   }
                 ]
@@ -1477,7 +1481,7 @@ type        : 'UI Behavior'
       // lets only validate username to start
       $('.add.example .ui.form')
         .form({
-          username: ['empty', 'minLength[5]']
+          username: ['notEmpty', 'minLength[5]']
         })
       ;
       </div>
@@ -1490,13 +1494,13 @@ type        : 'UI Behavior'
             .form('add rule', 'gender', {
               rules: [
                 {
-                  type   : 'empty',
+                  type   : 'notEmpty',
                   prompt : 'Entering your gender is necessary'
                 }
               ]
             })
             // adding shorthand
-            .form('add rule', 'password', ['empty', 'minLength[5]'])
+            .form('add rule', 'password', ['notEmpty', 'minLength[5]'])
           ;
         })
       ;
@@ -1554,8 +1558,8 @@ type        : 'UI Behavior'
       $('.ui.form')
         .form({
           fields: {
-            gender: 'empty',
-            name: 'empty'
+            gender: 'notEmpty',
+            name: 'notEmpty'
           }
         })
       ;
@@ -1589,7 +1593,7 @@ type        : 'UI Behavior'
       $('.ui.form')
         .form(
           fields: {
-            name: 'empty'
+            name: 'notEmpty'
           }
         })
       ;
@@ -1617,7 +1621,7 @@ type        : 'UI Behavior'
               depends    : 'isDoctor',
               rules      : [
                 {
-                  type   : 'empty',
+                  type   : 'notEmpty',
                   prompt : 'Please enter the number of years you have been a doctor'
                 }
               ]
@@ -1820,7 +1824,7 @@ type        : 'UI Behavior'
               identifier: 'dog',
               rules: [
                 {
-                  type: 'empty',
+                  type: 'notEmpty',
                   prompt: 'You must have a dog to add'
                 },
                 {
@@ -2075,7 +2079,7 @@ type        : 'UI Behavior'
       </tr>
       <tr>
         <td>set auto check</td>
-        <td>Automatically adds the "empty" rule or automatically checks a checkbox for all fields with classname or attribute <code>required</code></td>
+        <td>Automatically adds the "notEmpty" rule or automatically checks a checkbox for all fields with classname or attribute <code>required</code></td>
       </tr>
       <tr>
         <td>set optional(identifier, bool = true)</td>
@@ -2157,7 +2161,7 @@ type        : 'UI Behavior'
           <tr>
             <td>autoCheckRequired</td>
             <td>false</td>
-            <td>Whether fields with classname or attribute <code>required</code> should automatically add the "empty" rule or automatically checks checkbox fields</td>
+            <td>Whether fields with classname or attribute <code>required</code> should automatically add the "notEmpty" rule or automatically checks checkbox fields</td>
           </tr>
           <tr>
             <td>errorFocus</td>
@@ -2208,7 +2212,7 @@ type        : 'UI Behavior'
                 range                : '{name} must be in a range from {min} to {max}',
                 maxValue             : '{name} must have a maximum value of {ruleValue}',
                 minValue             : '{name} must have a minimum value of {ruleValue}',
-                empty                : '{name} must have a value',
+                notEmpty             : '{name} must have a value',
                 checked              : '{name} must be checked',
                 email                : '{name} must be a valid e-mail',
                 url                  : '{name} must be a valid url',

--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -137,13 +137,10 @@ themes      : ['Default']
 
 
     <div class="no example">
-      <h4 class="ui header">Page Grids</h4>
+      <h4 class="ui header" data-deprecated="[2.0]Use 'ui grid container' instead">Page Grids</h4>
       <p>Grids are fluid and will automatically flow in size to take the maximum available width.</p>
       <p><a href="/elements/container.html">Containers</a> are elements designed to limit page content to a reasonable maximum width for display based on the size of the user's screen.</p>
       <p>Using a <a href="/elements/container.html#containers-using-grids"><code>ui grid container</code></a> is the best way to include top-level page content inside a grid.</p>
-      <div class="ui warning message">
-        <p>In version <code>1.x</code> of Semantic UI <code>page grid</code> were used to contain the maximum width of grids holding page content. Page grid have been deprecated in favor for the simpler <code>container</code> element.</p>
-      </div>
     </div>
 
 

--- a/server/files/javascript/home.js
+++ b/server/files/javascript/home.js
@@ -255,7 +255,7 @@ semantic.home.ready = function() {
           identifier : 'email',
           rules: [
             {
-              type   : 'empty',
+              type   : 'notEmpty',
               prompt : 'Please enter an e-mail'
             },
             {

--- a/server/files/javascript/new.js
+++ b/server/files/javascript/new.js
@@ -112,7 +112,7 @@ semantic.new.ready = function() {
           identifier  : 'first-name',
           rules: [
             {
-              type   : 'empty',
+              type   : 'notEmpty',
               prompt : 'Please enter your first name'
             }
           ]
@@ -121,7 +121,7 @@ semantic.new.ready = function() {
           identifier  : 'last-name',
           rules: [
             {
-              type   : 'empty',
+              type   : 'notEmpty',
               prompt : 'Please enter your last name'
             }
           ]

--- a/server/files/javascript/validate-form.js
+++ b/server/files/javascript/validate-form.js
@@ -56,7 +56,7 @@ semantic.validateForm.ready = function() {
       identifier  : 'first-name',
       rules: [
         {
-          type   : 'empty',
+          type   : 'notEmpty',
           prompt : 'Please enter your first name'
         }
       ]
@@ -74,7 +74,7 @@ semantic.validateForm.ready = function() {
       identifier  : 'name',
       rules: [
         {
-          type   : 'empty',
+          type   : 'notEmpty',
           prompt : 'Please enter your name'
         }
       ]
@@ -83,7 +83,7 @@ semantic.validateForm.ready = function() {
       identifier  : 'gender',
       rules: [
         {
-          type   : 'empty',
+          type   : 'notEmpty',
           prompt : 'Please select a gender'
         }
       ]
@@ -92,7 +92,7 @@ semantic.validateForm.ready = function() {
       identifier  : 'last-name',
       rules: [
         {
-          type   : 'empty',
+          type   : 'notEmpty',
           prompt : 'Please enter your last name'
         }
       ]
@@ -101,7 +101,7 @@ semantic.validateForm.ready = function() {
       identifier : 'username',
       rules: [
         {
-          type   : 'empty',
+          type   : 'notEmpty',
           prompt : 'Please enter a username'
         },
         {
@@ -123,7 +123,7 @@ semantic.validateForm.ready = function() {
       identifier : 'password',
       rules: [
         {
-          type   : 'empty',
+          type   : 'notEmpty',
           prompt : 'Please enter a password'
         },
         {
@@ -136,7 +136,7 @@ semantic.validateForm.ready = function() {
       identifier : 'password-confirm',
       rules: [
         {
-          type   : 'empty',
+          type   : 'notEmpty',
           prompt : 'Please confirm your password'
         },
         {
@@ -168,7 +168,7 @@ semantic.validateForm.ready = function() {
           identifier : 'special-name',
           rules: [
             {
-              type   : 'empty'
+              type   : 'notEmpty'
             }
           ]
         }
@@ -190,7 +190,7 @@ semantic.validateForm.ready = function() {
           identifier  : 'gender',
           rules: [
             {
-              type   : 'empty',
+              type   : 'notEmpty',
               prompt : 'Please enter a gender'
             }
           ]
@@ -199,7 +199,7 @@ semantic.validateForm.ready = function() {
           identifier  : 'name',
           rules: [
             {
-              type   : 'empty',
+              type   : 'notEmpty',
               prompt : 'Please enter your name'
             }
           ]
@@ -213,11 +213,11 @@ semantic.validateForm.ready = function() {
 /*  $autoForm
     .form({
       fields: {
-        name     : 'empty',
-        gender   : 'empty',
-        username : 'empty',
-        password : ['minLength[6]', 'empty'],
-        skills   : ['minCount[2]', 'empty'],
+        name     : 'notEmpty',
+        gender   : 'notEmpty',
+        username : 'notEmpty',
+        password : ['minLength[6]', 'notEmpty'],
+        skills   : ['minCount[2]', 'notEmpty'],
         terms    : 'checked'
       }
     })
@@ -246,7 +246,7 @@ semantic.validateForm.ready = function() {
         field1: {
           rules: [
             {
-              type   : 'empty'
+              type   : 'notEmpty'
             }
           ]
         },
@@ -263,7 +263,7 @@ semantic.validateForm.ready = function() {
             {
               type   : 'isExactly[cat]',
               prompt : function(value) {
-                if(value == 'dog') {
+                if(value === 'dog') {
                   return 'I told you to put cat, not dog!';
                 }
                 return 'That is not cat';
@@ -283,7 +283,7 @@ semantic.validateForm.ready = function() {
           depends    : 'isDoctor',
           rules      : [
             {
-              type   : 'empty',
+              type   : 'notEmpty',
               prompt : 'Please enter the number of years you have been a doctor'
             }
           ]
@@ -344,7 +344,7 @@ semantic.validateForm.ready = function() {
         dog: {
           rules: [
             {
-              type: 'empty',
+              type: 'notEmpty',
               prompt: 'You must have a dog to add'
             },
             {
@@ -367,7 +367,7 @@ semantic.validateForm.ready = function() {
         calendar: {
           rules: [
             {
-              type: 'empty',
+              type: 'notEmpty',
               prompt: 'You must select a date'
             }
           ]

--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -1755,8 +1755,15 @@ code.code .class b[data-tooltip~="order"]:hover {
   }
 }
 
+.deprecated:not(.floating),
 .newsince {
   margin-left: 1em !important;
+}
+
+tr[data-deprecated] {
+  position: relative;
+  font-style: italic;
+  background: #dddddd;
 }
 
 /* Linked UI */


### PR DESCRIPTION
## Description
- Added new `notEmpty` rule as of https://github.com/fomantic/Fomantic-UI/pull/2949
- marked the `empty` rule as deprecated
- Added a general deprecation labeling system via `data-deprecated` for `h4` and `tr` tags

## Screenshots
![image](https://github.com/fomantic/Fomantic-UI-Docs/assets/18379884/eaf06904-3786-4407-be25-719920ad55d6)
![image](https://github.com/fomantic/Fomantic-UI-Docs/assets/18379884/3e9486c0-94b6-4681-ae2e-1b9d88c60a1b)
![image](https://github.com/fomantic/Fomantic-UI-Docs/assets/18379884/30cace35-367b-407b-b201-1824d504aefb)
![image](https://github.com/fomantic/Fomantic-UI-Docs/assets/18379884/8ff2477b-ff0b-4100-8b67-bab02b2f828b)
