### PR TITLE
fix(build): added gulp install info when updating

### DIFF
--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -273,8 +273,16 @@ type        : 'Main'
       $ npm update fomantic-ui
     </div>
     <p>
-      This will install the latest version and will run the interactive installer to install any new
-      files which are required. You will need to rebuild Fomantic-UI after the installer has
+      This will install the latest version. When NPM finishes updating, a precompiled version of Fomantic-UI is already available inside the <code>dist</code> folder.
+      Starting from 2.9.0, the interactive installation prompt will not start automatically after npm update anymore. If you need a custom installed version of Fomantic-UI, you have to manually run the following right after npm update
+    </p>
+    <div class="ignored code" data-type="bash">
+      $ cd node_modules/fomantic-ui
+      $ npx gulp install
+    </div>
+
+    <p>
+      You will need to rebuild Fomantic-UI after the installer has
       finished.
     </p>
 


### PR DESCRIPTION
## Description
Added info about gulp install when updating fomantic (same as for installing)
Reported in the discord general channel

## Screemshot
![image](https://github.com/fomantic/Fomantic-UI-Docs/assets/18379884/5f182256-812a-4b35-b531-5286abecb5c9)
