### PR TITLE
feat(a11y): optional alt setting for embed, toast, dropdown and search

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -2022,6 +2022,9 @@ themes      : ['Default', 'GitHub', 'Material']
               // path to image to be displayed to the left (optional)
               "image"  : false,
 
+              // text for the alt attribute if an image is also provided above (optional)
+              "alt"  : '',
+
               // whether the image should be displayed in a different style (optional)
               "imageClass"  : "ui avatar image",
 
@@ -2683,6 +2686,7 @@ themes      : ['Default', 'GitHub', 'Material']
                   "name": "Avatar",
                   "value": "jenny",
                   "image": "https://fomantic-ui.com/images/avatar/small/jenny.jpg",
+                  "alt": "A picture of jenny",
                   "imageClass": "ui avatar image"
                 },
                 {
@@ -3559,6 +3563,7 @@ themes      : ['Default', 'GitHub', 'Material']
               type                 : 'type',       // type of dropdown element
               image                : 'image',      // optional image path
               imageClass           : 'imageClass', // optional individual class for image
+              alt                  : 'alt',        // optional alt text for image
               icon                 : 'icon',       // optional icon name
               iconClass            : 'iconClass',  // optional individual class for icon (for example to use flag instead)
               class                : 'class',      // optional individual class for item/header

--- a/server/documents/modules/embed.html.eco
+++ b/server/documents/modules/embed.html.eco
@@ -76,6 +76,7 @@ type        : 'UI Module'
       <div class="ui embed"
         data-source="youtube"
         data-id="O6Xo21L0ybE"
+        data-alt="A Youtube Video about a waving bear"
         data-placeholder="/images/image-16by9.png">
       </div>
 
@@ -164,6 +165,7 @@ type        : 'UI Module'
           data-source="youtube"
           data-id="O6Xo21L0ybE"
           data-icon="video"
+          data-alt="A video about a waving bear"
           data-placeholder="/images/bear-waving.jpg"
         ></div>
       </div>
@@ -176,6 +178,7 @@ type        : 'UI Module'
         $('.custom.example .ui.embed').embed({
           source      : 'youtube',
           id          : 'O6Xo21L0ybE',
+          alt         : 'A video about a waving bear',
           placeholder : '/images/bear-waving.jpg'
         });
       </div>
@@ -328,6 +331,16 @@ type        : 'UI Module'
           <td>Specifies an id value to replace with the <code>{id}</code> value found in templated urls</td>
         </tr>
         <tr>
+          <td>placeholder</td>
+          <td>false</td>
+          <td>Specifies a placeholder image path</td>
+        </tr>
+        <tr>
+          <td>alt</td>
+          <td>false</td>
+          <td>Specifies an alt attribute string for the placeholder image</td>
+        </tr>
+        <tr>
           <td>parameters</td>
           <td>false</td>
           <td>Specify an object containing key/value pairs to add to the iframes GET parameters</td>
@@ -454,6 +467,7 @@ type        : 'UI Module'
               id          : 'id',
               icon        : 'icon',
               placeholder : 'placeholder',
+              alt         : 'alt',
               source      : 'source',
               url         : 'url'
             }
@@ -481,7 +495,7 @@ type        : 'UI Module'
               iframe: function(url, parameters) {
                 // returns html for iframe
               },
-              placeholder: function(image, icon) {
+              placeholder: function(image, icon, alt) {
                // returns html for placeholder element
               }
             }

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -477,6 +477,7 @@ type        : 'UI Module'
             "title": "Result Title",
             "url": "/optional/url/on/click",
             "image": "optional-image.jpg",
+            "alt": "optional alt attribute text for the given image",
             "price": "Optional Price",
             "description": "Optional Description"
           },
@@ -865,6 +866,7 @@ type        : 'UI Module'
               categoryResults : 'results',     // array of results (category view)
               description     : 'description', // result description
               image           : 'image',       // result image
+              alt             : 'alt',         // result alt text for image
               price           : 'price',       // result price
               results         : 'results',     // array of results (standard)
               title           : 'title',       // result title

--- a/server/documents/modules/toast.html.eco
+++ b/server/documents/modules/toast.html.eco
@@ -934,6 +934,11 @@ themes      : ['Default']
             <td>If an URL to an image is given, that image will be shown to the left of the toast</td>
         </tr>
         <tr>
+            <td>alt</td>
+            <td>false</td>
+            <td>If <code>showImage</code> is true, the alt setting can provide a string used for the image alt attribute</td>
+        </tr>
+        <tr>
           <td>showIcon</td>
           <td>true</td>
           <td>Define if the toast should display an icon which matches to a given class. If a string is given, this will be used as icon classname</td>


### PR DESCRIPTION
## Description

info about new `alt` settings for dropdown, search and toast as of https://github.com/fomantic/Fomantic-UI/pull/3011 and https://github.com/fomantic/Fomantic-UI/pull/2809