### PR TITLE
feat(dropdown, search): highlightMatches info

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -235,6 +235,22 @@ themes      : ['Default', 'GitHub', 'Material']
       </div>
     </div>
 
+    <div class="highlight example" data-since="2.9.4">
+      <h4 class="ui header">
+        Highlight search matches
+      </h4>
+      <p>You can automatically highlight the matching strings inside the search results.</p>
+      <select class="ui fluid search dropdown" multiple id="highlightexample">
+        <%- @partial('examples/single/state-options') %>
+      </select>
+      <div class="evaluated code" data-type="javascript">
+      $('#highlightexample')
+        .dropdown({
+          highlightMatches: true
+        });
+      </div>
+    </div>
+
     <div class="dropdown example" data-since="2.4.2">
       <h4 class="ui header">
         Clearable Selection
@@ -3518,6 +3534,11 @@ themes      : ['Default', 'GitHub', 'Material']
           <td>false</td>
           <td data-since="2.7.2">When activated, searches will also match results for base diacritic letters. For example when searching for 'a', it will also match 'á' or 'â' or 'å' and so on...
               It will also ignore diacritics for the searchterm, so if searching for 'ó', it will match 'ó', but also 'o', 'ô' or 'õ' and so on... <div class="ui tiny horizontal red label">Not available in IE</div></td>
+        </tr>
+        <tr>
+          <td>highlightMatches</td>
+          <td>false</td>
+          <td data-since="2.9.4">Whether search result should highlight matching strings.</td>
         </tr>
       </tbody>
     </table>

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -166,7 +166,7 @@ type        : 'UI Module'
       <h4 class="ui header">
         Search ignoring Diacritics
       </h4>
-      <p>A selection dropdown can allow a user to ignore all Diacritics while searching.</p>
+      <p>A search field can allow a user to ignore all Diacritics while searching.</p>
       <div class="ui ignored info message">
           If you want to support IE using the <code>ignoreDiacritics</code> option, you have to include a polyfill for the   <code>String().normalize()</code> method like <a href="https://cdn.jsdelivr.net/npm/unorm@1.4.1/lib/unorm.min.js">unorm</a>.
       </div>
@@ -208,6 +208,53 @@ type        : 'UI Module'
                     { title: 'voilà'},
                     { title: 'whekī'},
                     { title: 'c Zoë'}
+                ]
+            })
+        ;
+      </div>
+    </div>
+
+    <div class="highlight example" data-since="2.9.4">
+      <h4 class="ui header">
+        Highlight search matches
+      </h4>
+      <p>A search field can highlight matching strings inside the search results.</p>
+      <div class="ui search" id="highlightexample">
+        <div class="ui icon input">
+          <input class="prompt" type="text" placeholder="Search...">
+          <i class="search icon"></i>
+        </div>
+        <div class="results"></div>
+      </div>
+      <div class="evaluated code" data-type="javascript">
+        $('#highlightexample')
+            .search({
+                highlightMatches: true,
+                source: [
+                    { title: 'Andorra' },
+                    { title: 'United Arab Emirates' },
+                    { title: 'Afghanistan' },
+                    { title: 'Antigua' },
+                    { title: 'Anguilla' },
+                    { title: 'Albania' },
+                    { title: 'Armenia' },
+                    { title: 'Netherlands Antilles' },
+                    { title: 'Angola' },
+                    { title: 'Argentina' },
+                    { title: 'American Samoa' },
+                    { title: 'Austria' },
+                    { title: 'Australia' },
+                    { title: 'Aruba' },
+                    { title: 'Aland Islands' },
+                    { title: 'Azerbaijan' },
+                    { title: 'Bosnia' },
+                    { title: 'Barbados' },
+                    { title: 'Bangladesh' },
+                    { title: 'Belgium' },
+                    { title: 'Burkina Faso' },
+                    { title: 'Bulgaria' },
+                    { title: 'Bahrain' },
+                    { title: 'Burundi' }
                 ]
             })
         ;
@@ -908,10 +955,20 @@ type        : 'UI Module'
           <td>Easing equation when using fallback Javascript animation. EaseOutExpo is included with search, for additional options you must include <a href="https://gsgd.co.uk/sandbox/jquery/easing/">easing equations</td>
         </tr>
         <tr>
+          <td>highlightMatches</td>
+          <td>false</td>
+          <td data-since="2.9.4">Whether search result should highlight matching strings.</td>
+        </tr>
+        <tr>
           <td>ignoreDiacritics</td>
           <td>false</td>
           <td data-since="2.7.2">When activated, searches will also match results for base diacritic letters. For example when searching for 'a', it will also match 'á' or 'â' or 'å' and so on...
               It will also ignore diacritics for the searchterm, so if searching for 'ó', it will match 'ó', but also 'o', 'ô' or 'õ' and so on... <div class="ui tiny horizontal red label">Not available in IE</div></td>
+        </tr>
+        <tr>
+          <td>ignoreSearchCase</td>
+          <td>true</td>
+          <td data-since="2.9.4">Whether to consider case sensitivity on local searching.</td>
         </tr>
         <tr>
           <td>type</td>


### PR DESCRIPTION
## Description
Examples and info about `highlightMatches` and `ignoreSearchCase` (for search) setting as of https://github.com/fomantic/Fomantic-UI/pull/2963

## Screenshots
![image](https://github.com/fomantic/Fomantic-UI-Docs/assets/18379884/a03b8e43-167b-4492-926d-9e97b8272c29)
![image](https://github.com/fomantic/Fomantic-UI-Docs/assets/18379884/23cf89ae-5d6a-4a84-befb-c77813ad0f23)
![image](https://github.com/fomantic/Fomantic-UI-Docs/assets/18379884/6853474a-dedd-4331-86b4-9cbe648d9338)

