### PR TITLE
fix(less): use cloudflare polyfill mirror

### DIFF
--- a/server/partials/less.html.eco
+++ b/server/partials/less.html.eco
@@ -1,4 +1,4 @@
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es5%2Ces2015"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es5%2Ces2015"></script>
 <script>
 window.less = {
   async        : true,


### PR DESCRIPTION
## Description
polyfill.io is out of service. We still need this as long as we support IE11 (until 2.10), as LESS uses JS functionality which does not work in IE11. ( See #308  )

This PR replaces the original URL by a cloudflare link as they mirrored the same functionality some time ago.
https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk
https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet

## Closes
https://github.com/fomantic/Fomantic-UI/discussions/3084


