### PR TITLE
fix(footer): x was formerly twitter

### DIFF
--- a/server/partials/footer.html
+++ b/server/partials/footer.html
@@ -25,7 +25,7 @@
             <svg width="1200" height="1227" viewBox="0 0 1200 1227" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z"></path>
             </svg>
-            Twitter
+            X (formerly Twitter)
           </a>
           <a class="item" href="https://medium.com/@fomantic" target="_blank">
             <i class="medium icon"></i>


### PR DESCRIPTION
## Description
Match Text to new X Icon

## Screenshot
![image](https://github.com/user-attachments/assets/f1405a02-b0a9-43bb-a1c9-9c38127e5a63)
