### PR TITLE
fix(flag): new name of north macedonia

### DIFF
--- a/server/files/javascript/emoji_strategy.js
+++ b/server/files/javascript/emoji_strategy.js
@@ -29277,7 +29277,7 @@ var emojiStrategy = [
     "unicode_output": "1f1f2-1f1f4"
   },
   "1f1f2-1f1f0": {
-    "name": "flag: Macedonia",
+    "name": "flag: Republic of North Macedonia",
     "category": "flags",
     "shortname": ":flag_mk:",
     "shortname_alternates": [":mk:"],

--- a/server/files/javascript/flag.js
+++ b/server/files/javascript/flag.js
@@ -525,8 +525,8 @@ semantic.emoji.ready = function() {
     alias: ''
   }, {
     countrycode: 'mk',
-    name: 'Macedonia',
-    alias: ''
+    name: 'Republic of North Macedonia',
+    alias: 'north macedonia'
   }, {
     countrycode: 'mg',
     name: 'Madagascar',


### PR DESCRIPTION
## Description
According to https://en.wikipedia.org/wiki/North_Macedonia , the related country flags name need correction

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/7143