### PR TITLE
fix(chore): simplify js formatting

### DIFF
--- a/server/documents/behaviors/api.html.eco
+++ b/server/documents/behaviors/api.html.eco
@@ -178,7 +178,7 @@ type        : 'UI Behavior'
             Follow
           </div>
         </div>
-        <div class="evaluated code" data-type="javascript">
+        <div class="evaluated code">
         // translates '/follow/{id}' to 'follow/22'
         $('.follow.button')
           .api({
@@ -286,7 +286,7 @@ type        : 'UI Behavior'
             <input type="text" class="search">
           </div>
         </div>
-        <div class="evaluated code" data-type="javascript">
+        <div class="evaluated code">
           $.fn.api.settings.api.search = '/search/?query={value}';
 
           $('.routed.example .search input')
@@ -393,7 +393,7 @@ type        : 'UI Behavior'
         <h4 class="ui header">Disabling Requests</h4>
         <p>As a convenience, API will automatically prevent requests from occurring on elements that are currently disabled.</p>
         <div class="ui disabled button">Disabled</div>
-        <div class="evaluated code" data-type="javascript">
+        <div class="evaluated code">
           // this will never occur
           $('.disabled.button')
             .api({
@@ -484,7 +484,7 @@ type        : 'UI Behavior'
           </div>
           <div class="ui submit button">Submit</div>
         </form>
-        <div class="evaluated code" data-type="javascript">
+        <div class="evaluated code">
           $('form .submit.button')
             .api({
               action: 'create user',

--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -900,7 +900,7 @@ type        : 'UI Behavior'
         <div class="ui submit button">Submit</div>
         <div class="ui error message"></div>
       </form>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.field.example form')
           .form({
             on: 'blur',
@@ -975,7 +975,7 @@ type        : 'UI Behavior'
         <div class="ui submit button">Submit</div>
         <div class="ui error message"></div>
       </form>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.type.example form')
           .form({
             on: 'blur',
@@ -1116,7 +1116,7 @@ type        : 'UI Behavior'
         <div class="ui submit button">Submit</div>
         <div class="ui error message"></div>
       </form>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.payment.example form')
           .form({
             on: 'blur',
@@ -1171,7 +1171,7 @@ type        : 'UI Behavior'
         <div class="ui submit button">Submit</div>
         <div class="ui error message"></div>
       </form>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.match.example form')
           .form({
             on: 'blur',
@@ -1219,7 +1219,7 @@ type        : 'UI Behavior'
         <div class="ui submit button">Submit</div>
         <div class="ui error message"></div>
       </form>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.length.example form')
           .form({
             on: 'blur',
@@ -1305,7 +1305,7 @@ type        : 'UI Behavior'
         <div class="ui submit button">Submit</div>
         <div class="ui error message"></div>
       </form>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.content.example form')
           .form({
             on: 'blur',
@@ -1430,7 +1430,7 @@ type        : 'UI Behavior'
         <div class="ui submit button">Submit</div>
         <div class="ui error message"></div>
       </form>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.multi.example form')
           .form({
             on: 'blur',
@@ -1486,7 +1486,7 @@ type        : 'UI Behavior'
         })
       ;
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       // lets toggle some validation based on button
       $('.add.example .ui.positive.button')
         .on('click', function() {
@@ -1506,7 +1506,7 @@ type        : 'UI Behavior'
         })
       ;
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('.add.example .ui.negative.button')
         .on('click', function() {
           $('.add.example .ui.form')

--- a/server/documents/behaviors/state.html.eco
+++ b/server/documents/behaviors/state.html.eco
@@ -50,7 +50,7 @@ type        : 'UI Behavior'
 
     <div class="example">
       <h4 class="ui header">API example</h4>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         // typically you'd define all your templated urls in one config file
         $.fn.api.settings.api.follow = '/follow/{id}/'
         $('.foo.button')
@@ -75,7 +75,7 @@ type        : 'UI Behavior'
 
     <div class="example">
       <h4 class="ui header">Text example</h4>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         // Changes button between Follow and Following
         $('.follow.button')
           .state({
@@ -90,7 +90,7 @@ type        : 'UI Behavior'
     </div>
 
     <div class="another example">
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         // Changes text on activation and hover
         // The hover text is different when active and inactive
         $('.vote.button')

--- a/server/documents/behaviors/visibility.html.eco
+++ b/server/documents/behaviors/visibility.html.eco
@@ -555,7 +555,7 @@ type        : 'UI Behavior'
 
       <p>By default images will appear without animation, however you can also specify a named <a href="/modules/transition.html">transition</a>, and a duration that should be used for animating the image into view</p>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.demo.items .image img')
           .visibility({
             type       : 'image',
@@ -681,7 +681,7 @@ type        : 'UI Behavior'
       <h4 class="ui header">Gradual Changes</h4>
       <p>Each callback receives all calculated values as its first parameter, allowing you to adjust an element using </p>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.changing.example .demo.segment')
           .visibility({
             once       : false,
@@ -707,7 +707,7 @@ type        : 'UI Behavior'
       <div class="ui ignored warning message">
         You may need to adjust your fixed content's <code>z-index</code> to ensure it appears above other page content.
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.overlay.example .overlay')
           .visibility({
             type   : 'fixed',
@@ -764,7 +764,7 @@ type        : 'UI Behavior'
       <h4 class="ui header">Infinite Scroll</h4>
       <p>As an alternative to pagination you can use <code>onBottomVisible</code> to load content automatically when the bottom of a container is reached.</p>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.infinite.example .demo.segment')
           .visibility({
             once: false,

--- a/server/documents/collections/form.html.eco
+++ b/server/documents/collections/form.html.eco
@@ -291,7 +291,7 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
     <div class="ui ignored info message">
       UI checkbox are special, styled versions of standard HTML checkboxes.
     </div>
-    <div class="evaluated code" data-type="javascript" data-label="true">
+    <div class="evaluated code" data-label="true">
     $('.ui.checkbox')
       .checkbox()
     ;
@@ -322,7 +322,7 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
   <div data-use-content="true" class="example">
     <h4 class="ui header">Radio Checkbox</h4>
     <p>A form can include a <a href="/modules/checkbox.html#radio">radio checkbox</a></p>
-    <div class="evaluated code" data-type="javascript" data-label="true">
+    <div class="evaluated code" data-label="true">
     $('.ui.radio.checkbox')
       .checkbox()
     ;

--- a/server/documents/index.html.eco
+++ b/server/documents/index.html.eco
@@ -114,7 +114,7 @@ standalone : false
         <p>Any arbitrary decision in a component is included as a setting that developers can modify.</p>
       </div>
       <div class="nine wide column">
-        <div class="hidden code" data-demo="true" data-type="javascript">
+        <div class="hidden code" data-demo="true">
           $('select.dropdown')
             .dropdown('set selected', ['meteor', 'ember'])
           ;
@@ -152,7 +152,7 @@ standalone : false
         </div>
       </div>
       <div class="nine wide column">
-        <div class="hidden code" data-demo="true" data-type="javascript">
+        <div class="hidden code" data-demo="true">
         $('.sequenced.images .image')
           .transition({
             debug     : true,

--- a/server/documents/introduction/new.html.eco
+++ b/server/documents/introduction/new.html.eco
@@ -1503,7 +1503,7 @@ type        : 'Main'
       <a class="ui button" data-url="/images/large-pdf.pdf">
         Open Top Aligned Modal
       </a>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.ui.special.modal')
           .modal({
             centered: false
@@ -1551,7 +1551,7 @@ type        : 'Main'
         </div>
         <div class="results"></div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         var categoryContent = [
           { category: 'South America', title: 'Brazil' },
           { category: 'South America', title: 'Peru' },
@@ -1589,7 +1589,7 @@ type        : 'Main'
 
       <div class="ui divider"></div>
       <img src="/images/avatar/small/elliot.jpg" data-title="Elliot Fu" data-content="Elliot has been a member since July 2012" class="ui avatar image">
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.centering.example .avatar.image').popup();
       </div>
     </div>
@@ -1641,7 +1641,7 @@ type        : 'Main'
           padding: 50px 8px;
         }
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.complex-popup.example .ui.button')
           .popup({
             movePopup: false,

--- a/server/documents/modules/accordion.html.eco
+++ b/server/documents/modules/accordion.html.eco
@@ -439,7 +439,7 @@ themes      : ['Default', 'Chubby']
         Starting from <span class="ui tiny horizontal black label">2.9.0</span> there also exists a <code>ignore</code> selector to be able to define elements which should <b>not</b> trigger the accordion toggle.
         <br>For example when a dropdown is part of the accordion title, you may not want to toggle the accordion when you click on the dropdown.
       </div>
-      <div class="ui code" data-type="javascript" data-demo="true">
+      <div class="ui code" data-demo="true">
         $('.trigger.example .accordion')
           .accordion({
             selector: {

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -32,7 +32,7 @@ themes      : ['Default']
           <input type="text" placeholder="Date/Time">
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('#standard_calendar')
         .calendar()
       ;
@@ -82,7 +82,7 @@ themes      : ['Default']
       <p>An inline calendar isn't shown in a popup</p>
       <div class="ui calendar" id="inline_calendar">
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('#inline_calendar')
         .calendar()
       ;
@@ -618,7 +618,7 @@ themes      : ['Default']
               <input type="text" placeholder="Date">
           </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('#adjacentdays_calendar')
         .calendar({
           selectAdjacentDays: true,
@@ -814,7 +814,7 @@ themes      : ['Default']
               <input type="text" placeholder="Date">
           </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
           $('#disabledmonth_calendar')
           .calendar({
             type: 'date',
@@ -841,7 +841,7 @@ themes      : ['Default']
               <input type="text" placeholder="Date">
           </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
           $('#disabledyear_calendar')
           .calendar({
             type: 'date',
@@ -894,7 +894,7 @@ themes      : ['Default']
           <input type="text" placeholder="Date">
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('#eventdates_calendar').calendar({
           initialDate: new Date('2019-04-01'),
           eventDates: [
@@ -920,7 +920,7 @@ themes      : ['Default']
           <input type="text" placeholder="Date">
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('#eventdates2_calendar').calendar({
           initialDate: new Date('2019-04-01'),
           eventClass: 'inverted red',

--- a/server/documents/modules/checkbox.html.eco
+++ b/server/documents/modules/checkbox.html.eco
@@ -523,7 +523,7 @@ themes      : ['Default', 'Colored']
           </div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         var
           $console = $('.callback .console')
         ;
@@ -620,7 +620,7 @@ themes      : ['Default', 'Colored']
           </div>
         </div>
       </div>
-      <div class="evaluated code" data-title="Master Checkboxes" data-type="javascript">
+      <div class="evaluated code" data-title="Master Checkboxes">
         $('.list .master.checkbox')
           .checkbox({
             // check all children
@@ -640,7 +640,7 @@ themes      : ['Default', 'Colored']
           })
         ;
       </div>
-      <div class="evaluated code" data-title="Child Checkboxes" data-type="javascript">
+      <div class="evaluated code" data-title="Child Checkboxes">
         $('.list .child.checkbox')
           .checkbox({
             // Fire on load to set parent value
@@ -687,7 +687,7 @@ themes      : ['Default', 'Colored']
         <input type="checkbox" name="example" />
         <label>Maybe this will work</label>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.cancel.example .ui.checkbox')
           .checkbox({
             beforeChecked: function() {
@@ -706,7 +706,7 @@ themes      : ['Default', 'Colored']
       <p class="ignored">To make a user able to check a box, but unable to uncheck it, use the <code>uncheckable</code> setting.</p>
       <p class="ignored">To always disable a checkbox, add the property <code>disabled</code> to your input.</p>
       <p class="ignored">To make a checkbox read-only do not initialize it, or include the <code>read-only</code> class which will not allow events.</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.state.example .checkbox')
           .last()
           .checkbox({
@@ -739,7 +739,7 @@ themes      : ['Default', 'Colored']
     <div class="example">
       <h4 class="ui header">Attaching Events to other Elements</h4>
       <p>Checkbox can use the <code>attach events</code> behavior to attach events easily to other activating elements. This defaults to toggling, but other behaviors can be used as well.</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.test.checkbox').checkbox('attach events', '.toggle.button');
         $('.test.checkbox').checkbox('attach events', '.check.button', 'check');
         $('.test.checkbox').checkbox('attach events', '.uncheck.button', 'uncheck');

--- a/server/documents/modules/dimmer.html.eco
+++ b/server/documents/modules/dimmer.html.eco
@@ -288,7 +288,7 @@ themes      : ['Default']
     </div>
     <div class="partially example">
       <div class="ignored ui info message">Works also very well with transitions <code>fade up</code> or <code>fade down</code></div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('.partially.example .dimmer')
         .dimmer({
             transition: 'fade up',
@@ -324,7 +324,7 @@ themes      : ['Default']
     <div class="event example">
       <h4 class="ui header">Dimmer Events</h4>
       <p>A dimmer can trigger a visibility change on an event</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('.event.example .image')
         .dimmer({
           on: 'hover'
@@ -370,7 +370,7 @@ themes      : ['Default']
 
     <div class="dimmerloader example" data-since="2.7.0">
       <p>You can customize a loader in a dimmer via javascript</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
           $('.dimmerloader.example .image')
           .dimmer({
               displayLoader: true,

--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -225,7 +225,7 @@ themes      : ['Default', 'GitHub', 'Material']
             <div class="item">c Zoë</div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('#diacriticsexample')
         .dropdown({
           ignoreDiacritics: true,
@@ -243,7 +243,7 @@ themes      : ['Default', 'GitHub', 'Material']
       <select class="ui fluid search dropdown" multiple id="highlightexample">
         <%- @partial('examples/single/state-options') %>
       </select>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('#highlightexample')
         .dropdown({
           highlightMatches: true
@@ -1123,7 +1123,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <div class="item">I am a selectable entry only</div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.actionable.example .ui.dropdown')
           .dropdown({
             collapseOnActionable: false,
@@ -1676,7 +1676,7 @@ themes      : ['Default', 'GitHub', 'Material']
         classes currently available.
       </div>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.clearable.example .ui.selection.dropdown')
           .dropdown({
             clearable: true
@@ -1716,7 +1716,7 @@ themes      : ['Default', 'GitHub', 'Material']
         <%- @partial('examples/single/flag-menu') %>
       </div>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.max.example .ui.normal.dropdown')
           .dropdown({
             maxSelections: 3
@@ -1754,7 +1754,7 @@ themes      : ['Default', 'GitHub', 'Material']
         </div>
       </div>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.tag.example .ui.dropdown')
           .dropdown({
             allowAdditions: true
@@ -1788,7 +1788,7 @@ themes      : ['Default', 'GitHub', 'Material']
         </div>
       </div>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.stuck.example .ui.dropdown')
           .dropdown({
             allowAdditions: true,
@@ -1824,7 +1824,7 @@ themes      : ['Default', 'GitHub', 'Material']
         <%- @partial('examples/single/flag-menu') %>
       </div>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.label.example .ui.dropdown')
           .dropdown({
             useLabels: false
@@ -1858,7 +1858,7 @@ themes      : ['Default', 'GitHub', 'Material']
       <div class="ui button">
         Clear
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.clear.example .button')
           .on('click', function() {
             $('.clear.example .ui.dropdown')
@@ -1908,7 +1908,7 @@ themes      : ['Default', 'GitHub', 'Material']
       <div class="ui primary button">
           Restore All Dropdowns
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.restore.example .button')
           .on('click', function() {
             $('.restore.example .ui.dropdown')
@@ -1997,7 +1997,7 @@ themes      : ['Default', 'GitHub', 'Material']
         </div>
       </div>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.remote.filter.example .ui.dropdown')
           .dropdown({
             apiSettings: {
@@ -2111,7 +2111,7 @@ themes      : ['Default', 'GitHub', 'Material']
         </div>
       </div>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.remote.choices.example .ui.dropdown')
           .dropdown({
             apiSettings: {
@@ -2421,7 +2421,7 @@ themes      : ['Default', 'GitHub', 'Material']
         <p>A <a href="/elements/button.html">button</a> can be formatted with a dropdown.</p>
         <p>Using the <code>combo</code> action will change the preceding element to the selected value.</p>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('.combo.dropdown')
         .dropdown({
           action: 'combo'
@@ -2446,7 +2446,7 @@ themes      : ['Default', 'GitHub', 'Material']
       <h4 class="ui header">Link Dropdowns</h4>
       <div class="ignored">
         <p>Dropdowns support different default actions that can occur when an item is selected. For example, you can set your dropdown not to change its text, or select a value from its menu.</p>
-        <div class="evaluated code" data-type="javascript">
+        <div class="evaluated code">
         $('.link.example .dropdown')
           .dropdown({
             action: 'hide'
@@ -2693,7 +2693,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <h4 class="ui header">Display images and/or icons by value setting</h4>
           <p>Images and/or icons in front of an item can be dynamically created by providing image paths, icon names or classnames for different styling</p>
           <div class="ui ignored info message">Also works in a JSON response from a <code><a href="#match-search-query-on-server">remote API call</a></code></div>
-          <div class="evaluated code" data-type="javascript">
+          <div class="evaluated code">
               $('#imagesandicons').dropdown({
                 placeholder: 'Show images and icons',
                 values:[{
@@ -2742,7 +2742,7 @@ themes      : ['Default', 'GitHub', 'Material']
 
       <div class="no example">
           <p>To avoid adding the classNames to every item entry (for example if you want to display a list of avatars or flags), you could override the default setting for <code>className.image</code> or <code>className.icon</code> when initializing the dropdown</p>
-          <div class="evaluated code" data-type="javascript">
+          <div class="evaluated code">
               $('#allavatars').dropdown({
                 className: {
                   image: 'ui avatar image'
@@ -2773,7 +2773,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <h4 class="ui header">Display a (vertical) description by value setting</h4>
           <p>An additional item description (optionally displayed vertically) can be dynamically created by providing two extra attributes</p>
           <div class="ui ignored info message">Also works in a JSON response from a <code><a href="#match-search-query-on-server">remote API call</a></code></div>
-          <div class="evaluated code" data-type="javascript">
+          <div class="evaluated code">
               $('#verticaldescription').dropdown({
                   placeholder: 'Show (vertical) descriptions',
                   values:[{
@@ -2825,7 +2825,7 @@ themes      : ['Default', 'GitHub', 'Material']
       <div class="no example" data-since="2.7.7">
           <h4 class="ui header">Supporting image labels for multiselection</h4>
           <p>If needed, you can adjust the classname for multiselection labels to make use of <code><a href="/elements/label.html#image">image label</a></code></p>
-          <div class="evaluated code" data-type="javascript">
+          <div class="evaluated code">
               $('#imagelabels').dropdown({
                 className: {
                   label: 'ui image label',
@@ -2911,7 +2911,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <option value="female">Female</option>
         </select>
       </div>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#select')
           .dropdown()
         ;
@@ -2933,7 +2933,7 @@ themes      : ['Default', 'GitHub', 'Material']
                 <option value="b" data-text="I am Option B">Opt. B</option>
         </select>
       </div>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#data-text-select')
           .dropdown()
         ;
@@ -2973,7 +2973,7 @@ themes      : ['Default', 'GitHub', 'Material']
           </div>
         </div>
       </div>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#hybrid select')
           .dropdown({
             on: 'hover'
@@ -3007,7 +3007,7 @@ themes      : ['Default', 'GitHub', 'Material']
     <div class="no example">
       <h4 class="ui header">Searching Dropdowns</h4>
       <p>Using a <code>search selection dropdown</code> will allow you users to search more easily through large lists. This can also be converted directly from a form select element.</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#search-select')
           .dropdown()
         ;
@@ -3048,7 +3048,7 @@ themes      : ['Default', 'GitHub', 'Material']
       <h4 class="ui header">Multiple Selections</h4>
       <p>You can allow multiple selections by the <code>multiple</code> property on a <code>select</code> element, or by including the class <code>multiple</code> on a dropdown.</p>
       <p>When pre-existing HTML with a hidden input is used, values will be passed through a single value separated by a delimiter. The default is "," but this can be changed by adjusting the <code>delimiter</code> setting.</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#multi-select')
           .dropdown()
         ;
@@ -4208,7 +4208,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <div class="default text">Select Animal</div>
         </div>
 
-        <div class="evaluated code" data-type="javascript">
+        <div class="evaluated code">
         $('.ui.dropdown.evilexample')
           .dropdown({
             apiSettings: {
@@ -4226,7 +4226,7 @@ themes      : ['Default', 'GitHub', 'Material']
           <div class="default text">Select Animal</div>
         </div>
 
-        <div class="evaluated code" data-type="javascript">
+        <div class="evaluated code">
         $('.ui.dropdown.evilexample_sanitized')
           .dropdown({
             preserveHTML : false,

--- a/server/documents/modules/embed.html.eco
+++ b/server/documents/modules/embed.html.eco
@@ -129,7 +129,7 @@ type        : 'UI Module'
     <div class="no url example">
       <h4 class="ui header">Specifying a URL</h4>
       <p>Specifying a url will automatically match to an embed source using the domain of the url.</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('.url.example .ui.embed').embed();
       </div>
       <div class="code" data-type="html" data-preview="true">
@@ -143,7 +143,7 @@ type        : 'UI Module'
     <div class="no content example">
       <h4 class="ui header">Using Content IDs</h4>
       <p>Embed is designed to automatically generate urls from content ids. This way your site's backend can store meaningful content metadata and not worry about generating urls.</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('.content.example .ui.embed').embed();
       </div>
       <div class="code" data-type="html" data-preview="true">
@@ -157,7 +157,7 @@ type        : 'UI Module'
     <div class="no metadata example">
       <h4 class="ui header">Specifying Metadata</h4>
       <p>Other settings like icons and placeholder images can be specified in metadata overriding presets for a site.</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('.metadata.example .ui.embed').embed();
       </div>
       <div class="code" data-type="html" data-preview="true">
@@ -174,7 +174,7 @@ type        : 'UI Module'
     <div class="no custom example">
       <h4 class="ui header">Specifying Programmatically</h4>
       <p>You can also specify embed settings at run-time in the settings object.</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('.custom.example .ui.embed').embed({
           source      : 'youtube',
           id          : 'O6Xo21L0ybE',

--- a/server/documents/modules/flyout.html.eco
+++ b/server/documents/modules/flyout.html.eco
@@ -76,7 +76,7 @@ themes      : ['Default']
           </div>
         </div>
       </div>
-      <div class="code" data-demo="true" data-type="javascript" data-eval="$('.simple.flyout').flyout('toggle');">
+      <div class="code" data-demo="true" data-eval="$('.simple.flyout').flyout('toggle');">
       $('.ui.flyout')
         .flyout('toggle')
       ;
@@ -122,7 +122,7 @@ themes      : ['Default']
         <div class="ui top flyout"></div>
         <div class="ui bottom flyout"></div>
       </div>
-      <div class="code" data-demo="true" data-type="javascript" data-eval="$('.position.flyout').flyout('toggle');">
+      <div class="code" data-demo="true" data-eval="$('.position.flyout').flyout('toggle');">
       $('.ui.flyout')
         .flyout('toggle')
       ;
@@ -135,7 +135,7 @@ themes      : ['Default']
     <div class="no example">
       <h4 class="ui header">Fullscreen</h4>
       <p>A flyout can take all the entire screen if needed.</p>
-      <div class="code" data-demo="true" data-type="javascript" data-eval="$('.fullscreen.flyout').flyout('toggle');">
+      <div class="code" data-demo="true" data-eval="$('.fullscreen.flyout').flyout('toggle');">
         $('.ui.fullscreen.flyout')
           .flyout('toggle')
         ;
@@ -286,7 +286,7 @@ themes      : ['Default']
           </div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       // using context
       $('.context.example .ui.flyout')
         .flyout({
@@ -534,7 +534,7 @@ themes      : ['Default']
     <div class="no example">
       <h4 class="ui header">Create your own template</h4>
       <p>By extending the flyouts templates object once, you can define your own custom config templates. It has to return an object which will be merged into the flyouts settings prior to creating/showing the flyout.</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
   $.fn.flyout.settings.templates.greet = function(username) {
   // do something according to flyouts settings and/or given parameters
     var settings = this.get.settings(); // "this" is the flyout instance

--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -1186,7 +1186,7 @@ themes      : ['Default', 'Material']
     <div class="no example">
       <h4 class="ui header">Create your own template</h4>
       <p>By extending the modals templates object once, you can define your own custom config templates. It has to return an object which will be merged into the modals settings prior to creating/showing the modal.</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
   $.fn.modal.settings.templates.greet = function(username) {
   // do something according to modals settings and/or given parameters
     var settings = this.get.settings(); // "this" is the modal instance

--- a/server/documents/modules/nag.html.eco
+++ b/server/documents/modules/nag.html.eco
@@ -48,7 +48,7 @@ type        : 'UI Module'
         Look, i am a fixed nag!
         <i class="close icon"></i>
       </div>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
           /*
            persist:true is used to ignore dismiss storage when closing
            for demo purposes here, not related to 'fixed' variant
@@ -66,7 +66,7 @@ type        : 'UI Module'
         Look, I am a bottom fixed nag!
         <i class="close icon"></i>
       </div>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
           $('#bottomfixednag')
           .nag({
             persist:true
@@ -188,7 +188,7 @@ type        : 'UI Module'
           <i class="close icon"></i>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       // Automatically shows on init if cookie isn't set
       $('.cookie.nag')
         .nag({
@@ -197,13 +197,13 @@ type        : 'UI Module'
         })
       ;
       </div>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
       // Wont re-appear unless cleared
       $('.cookie.nag')
         .nag('show')
       ;
       </div>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
       // Clears cookie so nag shows again
       $('.cookie.nag')
         .nag('clear')

--- a/server/documents/modules/popup.html.eco
+++ b/server/documents/modules/popup.html.eco
@@ -624,7 +624,7 @@ themes      : ['Default']
       </h4>
       <p>Popups now include a new setting <code>boundary</code> that let you specify that a popup should not escape the boundary of another section. This can be useful in complex paned layouts</p>
       <p>Additionally popups can now specify a scroll context, to allow for scroll containers other than window to cause a clicked popup to hide on scroll.</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.boundary.example .button')
           .popup({
             boundary: '.boundary.example .segment'
@@ -645,7 +645,7 @@ themes      : ['Default']
 
       <p>Tweaking settings like the delay for show, and hide, and making the menu hoverable will help it function   more like a dropdown menu</p>
 
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('.example .menu .browse')
         .popup({
           inline     : true,
@@ -716,7 +716,7 @@ themes      : ['Default']
       <div class="ui warning ignored message">
         Using an <code>inline</code> popup may require specifying a <code>min-width</code> on your popup, if your popup content will appear outside the boundaries of its parent element.
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('.example .custom.button')
         .popup({
           popup : $('.custom.popup'),
@@ -736,7 +736,7 @@ themes      : ['Default']
     <div class="example">
       <h4 class="ui header">Specifying a trigger event</h4>
       <p>A popup trigger event can be specified</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
     $('.example .teal.button')
       .popup({
         on: 'click'
@@ -758,7 +758,7 @@ themes      : ['Default']
     <div class="example">
       <h4 class="ui header">Target Element</h4>
       <p>A popup can specify a different target element than itself to show a popup</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('.test.button')
         .popup({
           position : 'right center',
@@ -787,7 +787,7 @@ themes      : ['Default']
         color: #FF0000;
       }
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('.inline.icon')
         .popup({
           inline: true
@@ -841,7 +841,7 @@ themes      : ['Default']
         </div>
       </div>
       <div class="ui clearing divider"></div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
     $('.selection')
       .dropdown({
         onChange: function(value) {

--- a/server/documents/modules/progress.html.eco
+++ b/server/documents/modules/progress.html.eco
@@ -507,7 +507,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
     <div class="example">
       <h4 class="ui header">With metadata</h4>
       <p>A progress bar can be initialized with metadata</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#example1').progress();
       </div>
       <div class="code" data-type="html" data-preview="true">
@@ -520,7 +520,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
     <div class="example">
       <h4 class="ui header">With Javascript</h4>
       <p>A progress bar can be initialized with a Javascript settings object</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#example2').progress({
           percent: 22
         });
@@ -539,7 +539,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       <h4 class="ui header">Adding a Total Value</h4>
       <p>A progress bar can keep track of the current value as a ratio of a total value. This is useful for tracking the progress of a series of events with a known quantity, for example "uploading 1 of 20" photos.</p>
       <p>Each call to increment will increase the value by 1, or the value specified as the second parameter</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#example3')
           .progress('increment')
         ;
@@ -552,7 +552,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
           <div class="label">Adding Photos</div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('#example3')
           .progress({
             total: 3
@@ -566,7 +566,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
       <p>A progress bar can keep track of the current value as a ratio of a total value. This is useful for tracking the progress of a series of events with a known quantity, for example "uploading 1 of 20" photos.</p>
       <p>Each call to increment will increase the value by 1, or the value specified as the second parameter</p>
       <p>In addition you can pass in templates text for each state available to your progress bar which will automatically be updated when your progress bar reaches that state</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#example4')
           .progress('increment')
         ;
@@ -603,7 +603,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
           <td>Distance to total, or % progress left</td>
         </tr>
       </table>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#example5')
           .progress('increment')
         ;
@@ -614,7 +614,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
           <div class="label">Adding Photos</div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('#example5')
           .progress({
             text: {
@@ -629,7 +629,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
     <div class="example">
       <h4 class="ui header">Translation</h4>
       <p>You can also adjust text labels to help strings appear translated</p>
-      <div class="code" data-type="javascript" data-demo="true">
+      <div class="code" data-demo="true">
         $('#example6')
           .progress('increment')
         ;
@@ -642,7 +642,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
           <div class="label">Carga de archivos</div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('#example6')
           .progress({
             label: 'ratio',
@@ -822,7 +822,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
           <div class="label">Waiting for you to press button</div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('.rapid.example .ui.button')
           .on('click', function() {
             var
@@ -868,7 +868,7 @@ themes      : ['Default', 'Classic', 'Basic', 'Striped']
           <div class="label">Uploading File</div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript" data-demo="true">
+      <div class="evaluated code" data-demo="true">
         $('.upload.example .ui.button')
           .api({
             debug: true,

--- a/server/documents/modules/rating.html.eco
+++ b/server/documents/modules/rating.html.eco
@@ -202,7 +202,7 @@ themes      : ['Default']
     <div class="clearing no example">
       <h4 class="ui header">Clearing Ratings</h4>
       <p>When clearable is set to <code>true</code> you can clear the rating by clicking on the current start rating.</p>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       $('.clearing.example .rating')
         .rating('setting', 'clearable', true)
       ;

--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -177,7 +177,7 @@ type        : 'UI Module'
         </div>
         <div class="results"></div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('#diacriticsexample')
             .search({
                 ignoreDiacritics: true,
@@ -226,7 +226,7 @@ type        : 'UI Module'
         </div>
         <div class="results"></div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
         $('#highlightexample')
             .search({
                 highlightMatches: true,
@@ -1254,7 +1254,7 @@ type        : 'UI Module'
           </div>
         </div>
 
-        <div class="evaluated code" data-type="javascript">
+        <div class="evaluated code">
         $('.ui.search.evilexample')
           .search({
         	apiSettings: {
@@ -1277,7 +1277,7 @@ type        : 'UI Module'
           </div>
         </div>
 
-        <div class="evaluated code" data-type="javascript">
+        <div class="evaluated code">
         $('.ui.search.evilexample_sanitized')
           .search({
         	preserveHTML : false,

--- a/server/documents/modules/sidebar.html.eco
+++ b/server/documents/modules/sidebar.html.eco
@@ -47,7 +47,7 @@ themes      : ['Default']
           &lt;/div&gt;
         &lt;/body&gt;
       </div>
-      <div class="code" data-demo="true" data-type="javascript" data-eval="$('.simple.sidebar').sidebar('toggle');">
+      <div class="code" data-demo="true" data-eval="$('.simple.sidebar').sidebar('toggle');">
       $('.ui.sidebar')
         .sidebar('toggle')
       ;
@@ -70,7 +70,7 @@ themes      : ['Default']
           &lt;/a&gt;
         &lt;/div&gt;
       </div>
-      <div class="code" data-demo="true" data-type="javascript" data-eval="$('.left.demo.sidebar').sidebar('toggle');">
+      <div class="code" data-demo="true" data-eval="$('.left.demo.sidebar').sidebar('toggle');">
       $('.ui.labeled.icon.sidebar')
         .sidebar('toggle')
       ;
@@ -392,7 +392,7 @@ themes      : ['Default']
         If you are triggering multiple sidebars at the same time, its recommended to set the transition to overlay.
       </div>
 
-      <div class="code" data-demo="true" data-type="javascript">
+      <div class="code" data-demo="true">
       // showing multiple
       $('.demo.sidebar')
         .sidebar('setting', 'transition', 'overlay')
@@ -441,7 +441,7 @@ themes      : ['Default']
           </div>
         </div>
       </div>
-      <div class="evaluated code" data-type="javascript">
+      <div class="evaluated code">
       // using context
       $('.context.example .ui.sidebar')
         .sidebar({
@@ -524,7 +524,7 @@ themes      : ['Default']
           </div>
         </div>
       </div>
-      <div class="code" data-demo="true" data-type="javascript">
+      <div class="code" data-demo="true">
       // showing multiple
       $('.visible.example .ui.sidebar')
         .sidebar({

--- a/server/documents/modules/slider.html.eco
+++ b/server/documents/modules/slider.html.eco
@@ -73,7 +73,7 @@ themes      : ['Default']
         <p>You can provide a function which returns a custom label according to the label value</p>
         <div class="ui labeled ticked slider" id="interpretedlabel"></div>
     </div>
-    <div class="evaluated code" data-type="javascript">
+    <div class="evaluated code">
         var labels = ["α", "β", "γ", "δ", "ε", "ζ", "η", "θ", "ι", "κ", "λ", "μ", "ν", "ξ", "ο", "π", "ρ", "σ/ς", "τ", "υ", "φ", "χ", "ψ", "ω"];
         $('#interpretedlabel')
           .slider({

--- a/server/documents/modules/toast.html.eco
+++ b/server/documents/modules/toast.html.eco
@@ -30,7 +30,7 @@ themes      : ['Default']
     <div class="no example">
         <h4 class="ui header">Minimal</h4>
         <p>A minimal toast will just display a message.</p>
-        <div class="code" data-demo="true" data-type="javascript">
+        <div class="code" data-demo="true">
         $.toast({
           message: 'I am a toast, nice to meet you !'
         })
@@ -41,7 +41,7 @@ themes      : ['Default']
     <div class="no example">
         <h4 class="ui header">Titled</h4>
         <p>You can add a title to your toast.</p>
-        <div class="code" data-demo="true" data-type="javascript">
+        <div class="code" data-demo="true">
         $.toast({
           title: 'Better ?',
           message: 'Hey look, I have a title !'
@@ -53,7 +53,7 @@ themes      : ['Default']
     <div class="no example" data-since="2.6.3">
         <h4 class="ui header">Progress Bar</h4>
         <p>You can attach a progress bar to your toast.</p>
-        <div class="code" data-demo="true" data-type="javascript">
+        <div class="code" data-demo="true">
         $.toast({
           title: 'LOOK',
           message: 'See, how long i will last',
@@ -62,7 +62,7 @@ themes      : ['Default']
         ;
         </div>
         <p>The progress bar can have its own individual color</p>
-        <div class="code" data-demo="true" data-type="javascript">
+        <div class="code" data-demo="true">
         $.toast({
           title: 'LOOK',
           message: 'See, how long i will last',
@@ -78,14 +78,14 @@ themes      : ['Default']
     <div class="no example">
         <h4 class="ui header">Toast Type</h4>
         <p>A toast can be used to display different types of informations.</p>
-        <div class="code" data-demo="true" data-type="javascript">
+        <div class="code" data-demo="true">
         $.toast({
           class: 'success',
           message: `You're using the good framework !`
         })
         ;
         </div>
-        <div class="code" data-demo="true" data-type="javascript">
+        <div class="code" data-demo="true">
         $.toast({
           class: 'error',
           message: `An error occurred !`

--- a/server/documents/modules/transition.html.eco
+++ b/server/documents/modules/transition.html.eco
@@ -309,7 +309,7 @@ type        : 'UI Module'
     <div class="examples">
       <h2 class="ui dividing header">Visibility</h2>
       <p>After the animation queue finishes for an element, its final visibility state is determined. If an animation is an outward transition, the final visibility status will be hidden. If an animation is inward the element will be visible after the animation finishes.</p>
-      <div class="code" data-type="javascript" data-demo="true" data-title="Disappearing element">
+      <div class="code" data-demo="true" data-title="Disappearing element">
       $('.long.leaf.image')
         .transition('scale')
       ;

--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -262,7 +262,7 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
     </div>
   </div>
   <div class="another example">
-    <div class="evaluated code" data-type="javascript">
+    <div class="evaluated code">
     $('.special.cards .image').dimmer({
     // As hover is not working on mobile, you might use click on those devices as fallback
       on: 'ontouchstart' in document.documentElement ? 'click' : 'hover'

--- a/server/files/javascript/docs.js
+++ b/server/files/javascript/docs.js
@@ -997,7 +997,7 @@ semantic.ready = function() {
         formattedCode = code
       ;
 
-      contentType = contentType.toLowerCase();
+      contentType = demo || evaluatedCode ? 'javascript' : contentType.toLowerCase();
 
       function escapeHTML(string) {
         return $('<div>').html(string).text();


### PR DESCRIPTION
## Description
This PR sets the default code formatting to javascript instead of HTML for all demo or evaluated code fragments.
This reduces code and fixes all non correctly styled JS code

## Screenshots
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/6380e8cf-d258-4072-bf28-ee95e77cd751)|![image](https://github.com/user-attachments/assets/92e95af7-5232-4e44-923d-fe033c9b6cc7)|