### PR TITLE
feat(calendar): detailed on setting

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -1130,7 +1130,7 @@ themes      : ['Default']
         <tr>
           <td>on</td>
           <td>null</td>
-          <td>Choose when to show the popup (defaults to <code>click</code>)</td>
+          <td>Event used to trigger calendar popup. Can be either <b>focus, click or hover</b> (defaults to <code>click</code>)</td>
         </tr>
         <tr>
           <td>initialDate</td>


### PR DESCRIPTION
## Description
The `on` setting for calendar is forwarded to the internal popup usage. This wasnt clear, so i copied the relevant setting description from popup to calender  as well