### PR TITLE
feat(calendar): document usage scope of format tokens

### DIFF
--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -340,7 +340,7 @@ themes      : ['Default']
       <h4 class="ui header">Custom format</h4>
       <p>You can entirely change the date format by using a token string formatter.</p>
       <p>The format is applied to several date outputs mentioned as tokens in the <a href="#/settings">formatter settings</a>.</p>
-      <p>These same tokens can be used to format the date gotten through <a href="#/usage>behaviors</a>, like 'get date'.</p>
+      <p>These same tokens can also be used to format the date gotten through <a href="#/usage>behaviors</a>, like 'get date'.</p>
       <p>
         Tokens are placeholder characters for a specific output format. Fomantic-UI supports the following tokens:
         <table class="ui celled table">

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -339,6 +339,8 @@ themes      : ['Default']
     <div class="example" data-since="2.9.0">
       <h4 class="ui header">Custom format</h4>
       <p>You can entirely change the date format by using a token string formatter.</p>
+      <p>The format is applied to the calendar cells.</p>
+      <p>These same tokens can be used to format the date gotten through <a href="#/usage>behaviors</a>.</p>
       <p>
         Tokens are placeholder characters for a specific output format. Fomantic-UI supports the following tokens:
         <table class="ui celled table">
@@ -982,8 +984,9 @@ themes      : ['Default']
         <td>Clear the selected date</td>
       </tr>
       <tr>
-        <td>get date</td>
-        <td>Get the selected date</td>
+        <td>get date(format = '')</td>
+        <td>Get the selected date.
+        If <code>format</code> is omitted, a JavaScript date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
       </tr>
       <tr>
         <td>set date(date, updateInput = true, fireChange = true)</td>
@@ -998,24 +1001,27 @@ themes      : ['Default']
         <td>Set the current selection mode (<code>year</code>, <code>month</code>, <code>day</code>, <code>hour</code>, <code>minute</code>)</td>
       </tr>
       <tr>
-        <td>get startDate</td>
-        <td>Get the start date for range selection</td>
+        <td>get startDate(format = '')</td>
+        <td>Get the start date for range selection.
+        If <code>format</code> is omitted, a JavaScript date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
       </tr>
       <tr>
         <td>set startDate(date)</td>
         <td>Set the start date for range selection</td>
       </tr>
       <tr>
-        <td>get endDate</td>
-        <td>Get the end date for range selection</td>
+        <td>get endDate(format = '')</td>
+        <td>Get the end date for range selection.
+        If <code>format</code> is omitted, a JavaScript date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
       </tr>
       <tr>
         <td>set endDate(date)</td>
         <td>Set the end date for range selection</td>
       </tr>
       <tr>
-        <td>get focusDate</td>
-        <td>Get the currently focused date</td>
+        <td>get focusDate(format = '')</td>
+        <td>Get the currently focused date.
+        If <code>format</code> is omitted, a JavaScript date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
       </tr>
       <tr>
         <td>set focusDate(date)</td>

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -339,8 +339,8 @@ themes      : ['Default']
     <div class="example" data-since="2.9.0">
       <h4 class="ui header">Custom format</h4>
       <p>You can entirely change the date format by using a token string formatter.</p>
-      <p>The format is applied to the calendar cells.</p>
-      <p>These same tokens can be used to format the date gotten through <a href="#/usage>behaviors</a>.</p>
+      <p>The format is applied to several date outputs mentioned as tokens in the <a href="#/settings">formatter settings</a>, like calendar cells.</p>
+      <p>These same tokens can be used to format the date gotten through <a href="#/usage>behaviors</a>, like 'get date'.</p>
       <p>
         Tokens are placeholder characters for a specific output format. Fomantic-UI supports the following tokens:
         <table class="ui celled table">

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -986,7 +986,7 @@ themes      : ['Default']
       <tr>
         <td>get date(format = '')</td>
         <td>Get the selected date.
-        If <code>format</code> is omitted, a JavaScript date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
+        If <code>format</code> is omitted, a JavaScript Date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
       </tr>
       <tr>
         <td>set date(date, updateInput = true, fireChange = true)</td>
@@ -1003,7 +1003,7 @@ themes      : ['Default']
       <tr>
         <td>get startDate(format = '')</td>
         <td>Get the start date for range selection.
-        If <code>format</code> is omitted, a JavaScript date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
+        If <code>format</code> is omitted, a JavaScript Date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
       </tr>
       <tr>
         <td>set startDate(date)</td>
@@ -1012,7 +1012,7 @@ themes      : ['Default']
       <tr>
         <td>get endDate(format = '')</td>
         <td>Get the end date for range selection.
-        If <code>format</code> is omitted, a JavaScript date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
+        If <code>format</code> is omitted, a JavaScript Date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
       </tr>
       <tr>
         <td>set endDate(date)</td>
@@ -1021,7 +1021,7 @@ themes      : ['Default']
       <tr>
         <td>get focusDate(format = '')</td>
         <td>Get the currently focused date.
-        If <code>format</code> is omitted, a JavaScript date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
+        If <code>format</code> is omitted, a JavaScript Date object is returned, otherwise a <a href="/modules/calendar.html#custom-format">formatted string</a> is returned.</td>
       </tr>
       <tr>
         <td>set focusDate(date)</td>

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -339,7 +339,7 @@ themes      : ['Default']
     <div class="example" data-since="2.9.0">
       <h4 class="ui header">Custom format</h4>
       <p>You can entirely change the date format by using a token string formatter.</p>
-      <p>The format is applied to several date outputs mentioned as tokens in the <a href="#/settings">formatter settings</a>, like calendar cells.</p>
+      <p>The format is applied to several date outputs mentioned as tokens in the <a href="#/settings">formatter settings</a>.</p>
       <p>These same tokens can be used to format the date gotten through <a href="#/usage>behaviors</a>, like 'get date'.</p>
       <p>
         Tokens are placeholder characters for a specific output format. Fomantic-UI supports the following tokens:


### PR DESCRIPTION
Improve the documentation for the original usage, emphasizing that a JavaScript Date object was being returned by the relevant Calendar Behaviors.

Also, document the new Behaviors with the optional `format` parameter.

Documents: https://github.com/fomantic/Fomantic-UI/pull/3141 