### PR TITLE
fix(input): move left icon to support icon opacity

### DIFF
--- a/server/documents/behaviors/form.html.eco
+++ b/server/documents/behaviors/form.html.eco
@@ -1879,8 +1879,8 @@ type        : 'UI Behavior'
           <label>Date</label>
           <div class="ui calendar">
             <div class="ui input left icon">
-              <i class="calendar icon"></i>
               <input type="text" name="calendar" placeholder="Date">
+              <i class="calendar icon"></i>
             </div>
           </div>
         </div>

--- a/server/documents/collections/form.html.eco
+++ b/server/documents/collections/form.html.eco
@@ -960,8 +960,8 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
         <label>Date</label>
         <div class="ui calendar">
           <div class="ui input left icon">
-            <i class="calendar icon"></i>
             <input type="text" placeholder="Pick up a date" name="date">
+            <i class="calendar icon"></i>
           </div>
         </div>
       </div>

--- a/server/documents/elements/divider.html.eco
+++ b/server/documents/elements/divider.html.eco
@@ -103,8 +103,8 @@ themes      : ['default']
     <div class="ui ignored info message">Dividers will automatically vary the size of their dividing rules to match the length of your text</div>
     <div class="ui center aligned basic segment">
       <div class="ui left icon action input">
-        <i class="search icon"></i>
         <input type="text" placeholder="Order #">
+        <i class="search icon"></i>
         <div class="ui blue submit button">Search</div>
       </div>
       <div class="ui horizontal divider">

--- a/server/documents/elements/input.html.eco
+++ b/server/documents/elements/input.html.eco
@@ -221,8 +221,8 @@ themes      : ['Default', 'GitHub']
   </div>
   <div class="another example">
     <div class="ui right labeled left icon input">
-      <i class="tags icon"></i>
       <input type="text" placeholder="Enter tags">
+      <i class="tags icon"></i>
       <a class="ui tag label">
         Add Tag
       </a>
@@ -286,8 +286,8 @@ themes      : ['Default', 'GitHub']
   </div>
   <div class="another example">
     <div class="ui right action left icon input">
-      <i class="search icon"></i>
       <input type="text" placeholder="Search">
+      <i class="search icon"></i>
       <div class="ui basic floating dropdown button">
         <div class="text">This Page</div>
         <i class="dropdown icon"></i>

--- a/server/documents/index.html.eco
+++ b/server/documents/index.html.eco
@@ -887,8 +887,8 @@ standalone : false
             <a href="/elements/input.html">Input</a>
           </h4>
           <div class="ui action left icon input">
-            <i class="search icon"></i>
             <input type="text" placeholder="Search...">
+            <i class="search icon"></i>
             <div class="ui teal button">Search</div>
           </div>
           <div class="ui hidden divider"></div>

--- a/server/documents/introduction/new.html.eco
+++ b/server/documents/introduction/new.html.eco
@@ -840,8 +840,8 @@ type        : 'Main'
       <h4 class="ui header">Calendar</h4>
       <div class="ui calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date/Time">
+          <i class="calendar icon"></i>
         </div>
       </div>
     </div>

--- a/server/documents/modules/calendar.html.eco
+++ b/server/documents/modules/calendar.html.eco
@@ -28,8 +28,8 @@ themes      : ['Default']
       <p>A standard calendar</p>
       <div class="ui calendar" id="standard_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date/Time">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="evaluated code">
@@ -48,8 +48,8 @@ themes      : ['Default']
             <label>Start date</label>
             <div class="ui calendar" id="rangestart">
               <div class="ui input left icon">
-                <i class="calendar icon"></i>
                 <input type="text" placeholder="Start">
+                <i class="calendar icon"></i>
               </div>
             </div>
           </div>
@@ -57,8 +57,8 @@ themes      : ['Default']
             <label>End date</label>
             <div class="ui calendar" id="rangeend">
               <div class="ui input left icon">
-                <i class="calendar icon"></i>
                 <input type="text" placeholder="End">
+                <i class="calendar icon"></i>
               </div>
             </div>
           </div>
@@ -95,22 +95,22 @@ themes      : ['Default']
       <p>A calendar can have different sizes</p>
       <div class="ui tiny calendar" id="tiny_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date/Time">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <br />
       <div class="ui medium calendar" id="medium_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date/Time">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <br />
       <div class="ui big calendar" id="big_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date/Time">
+          <i class="calendar icon"></i>
         </div>
       </div>
     </div>
@@ -120,8 +120,8 @@ themes      : ['Default']
       <p>A calendar can have its colors inverted</p>
       <div class="ui inverted calendar" id="inverted_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date/Time">
+          <i class="calendar icon"></i>
         </div>
       </div>
     </div>
@@ -131,8 +131,8 @@ themes      : ['Default']
       <p>You can display multiple months. Use <code>monthOffset</code>, to adjust the the startmonth relative to the selected date</p>
       <div class="ui calendar" id="multimonth_calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -152,8 +152,8 @@ themes      : ['Default']
       <p>A disabled calendar does not allow user interaction</p>
       <div class="ui disabled calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date/Time">
+          <i class="calendar icon"></i>
         </div>
       </div>
     </div>
@@ -169,8 +169,8 @@ themes      : ['Default']
       <p>A date calendar disable the time selection</p>
       <div class="ui calendar" id="date_calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -187,8 +187,8 @@ themes      : ['Default']
       <p>A time calendar disable the date selection</p>
       <div class="ui calendar" id="time_calendar">
         <div class="ui input left icon">
-          <i class="time icon"></i>
           <input type="text" placeholder="Time">
+          <i class="time icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -204,8 +204,8 @@ themes      : ['Default']
       <div class="ui ignored info message">This could be useful when used with form validation without the need to instantiate the calendar via javascript before. Form validation recognizes a calendar component within the form and instantiates it automatically by using existing metadata values.</div>
       <div class="ui calendar" id="type_calendar" data-type="date" data-date="2019-12-24">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
     </div>
@@ -215,8 +215,8 @@ themes      : ['Default']
       <p>A year first calendar allow you to select a date by starting to select a year</p>
       <div class="ui calendar" id="year_first_calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -234,8 +234,8 @@ themes      : ['Default']
       <div class="ui ignored info message">For details about the token string format see <a href="#custom-format">Custom Format</a></div>
       <div class="ui calendar" id="no_ampm">
         <div class="ui input left icon">
-          <i class="time icon"></i>
           <input type="text" placeholder="Time">
+          <i class="time icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -256,8 +256,8 @@ themes      : ['Default']
       <p>A month and year calendar disable the date and time selection</p>
       <div class="ui calendar" id="month_year_calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -274,8 +274,8 @@ themes      : ['Default']
       <p>A year calendar allow you to select a year only</p>
       <div class="ui calendar" id="year_calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -292,8 +292,8 @@ themes      : ['Default']
       <p>You can set a minimum and a maximum selection date</p>
       <div class="ui calendar" id="minmax_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -311,8 +311,8 @@ themes      : ['Default']
       <p>You can also set a minimum and a maximum selection date using HTML markup</p>
       <div class="ui calendar" id="minmax_calendar_2" data-min-date="2018/10/05 08:00:00" data-max-date="2018/10/19 18:00:00">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
     </div>
@@ -322,8 +322,8 @@ themes      : ['Default']
       <p>You can chose to use a day first display calendar (parsing and conversion are impacted too)</p>
       <div class="ui calendar" id="day_first_calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -502,8 +502,8 @@ themes      : ['Default']
 
       <div class="ui calendar" id="token_format_calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date" readonly>
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -521,8 +521,8 @@ themes      : ['Default']
       <p>You can also provide a custom function to return anything you want</p>
       <div class="ui calendar" id="custom_format_calendar">
         <div class="ui input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date" readonly>
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -547,8 +547,8 @@ themes      : ['Default']
       <h5>Example 1:<br> Shortyears 00-99 -> 2000-2099</h5>
         <div class="ui calendar" id="shortyear_example1">
             <div class="ui input left icon">
-                <i class="calendar icon"></i>
                 <input type="text" placeholder="Date">
+                <i class="calendar icon"></i>
             </div>
         </div>
         <div class="code" data-type="javascript">
@@ -564,8 +564,8 @@ themes      : ['Default']
       <h5>Example 2:<br> Shortyears 00-99 -> 1900-1999</h5>
       <div class="ui calendar" id="shortyear_example2">
           <div class="ui input left icon">
-              <i class="calendar icon"></i>
               <input type="text" placeholder="Date">
+              <i class="calendar icon"></i>
           </div>
       </div>
       <div class="code" data-type="javascript">
@@ -582,8 +582,8 @@ themes      : ['Default']
           Shortyears 60-99 -> 2900-2959</h5>
       <div class="ui calendar" id="shortyear_example3">
           <div class="ui input left icon">
-              <i class="calendar icon"></i>
               <input type="text" placeholder="Date">
+              <i class="calendar icon"></i>
           </div>
       </div>
       <div class="code" data-type="javascript">
@@ -600,8 +600,8 @@ themes      : ['Default']
           Shortyears 40-99 -> 1740-1799</h5>
       <div class="ui calendar" id="shortyear_example4">
           <div class="ui input left icon">
-              <i class="calendar icon"></i>
               <input type="text" placeholder="Date">
+              <i class="calendar icon"></i>
           </div>
       </div>
       <div class="code" data-type="javascript">
@@ -620,8 +620,8 @@ themes      : ['Default']
       <p>It's possible to also select adjacent days of the previous and next month in the current month view instead of being disabled</p>
       <div class="ui calendar" id="adjacentdays_calendar">
           <div class="ui input left icon">
-              <i class="calendar icon"></i>
               <input type="text" placeholder="Date">
+              <i class="calendar icon"></i>
           </div>
       </div>
       <div class="evaluated code">
@@ -639,8 +639,8 @@ themes      : ['Default']
       <p>It's possible to change the calendar language to fit with your needs</p>
       <div class="ui calendar" id="french_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date/Time">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -687,8 +687,8 @@ themes      : ['Default']
       <div class="ui calendar" id="context_calendar">
         <div class='ui very short scrolling segment'>
           <div class="ui fluid input left icon">
-            <i class="calendar icon"></i>
             <input type="text" placeholder="Date">
+            <i class="calendar icon"></i>
           </div>
           <p>
           Some text ...<br>
@@ -718,8 +718,8 @@ themes      : ['Default']
       <p>Disable each Monday, Wednesday and Friday from selection</p>
       <div class="ui calendar" id="disableddaysofweek_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -735,8 +735,8 @@ themes      : ['Default']
       <p>Disabling specific single dates which can optionally display a reason in popup on hover</p>
       <div class="ui calendar" id="disableddates_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="code" data-type="javascript">
@@ -764,8 +764,8 @@ themes      : ['Default']
       <p>Disabling specific hours of specific days which can optionally display a reason in popup on hover</p>
       <div class="ui calendar" id="disabledhours_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
 
@@ -816,8 +816,8 @@ themes      : ['Default']
       <p>It's possible to disable all days of specific months</p>
       <div class="ui calendar" id="disabledmonth_calendar">
           <div class="ui input left icon">
-              <i class="calendar icon"></i>
               <input type="text" placeholder="Date">
+              <i class="calendar icon"></i>
           </div>
       </div>
       <div class="evaluated code">
@@ -843,8 +843,8 @@ themes      : ['Default']
       <p>It's possible to disable all days of a whole year</p>
       <div class="ui calendar" id="disabledyear_calendar">
           <div class="ui input left icon">
-              <i class="calendar icon"></i>
               <input type="text" placeholder="Date">
+              <i class="calendar icon"></i>
           </div>
       </div>
       <div class="evaluated code">
@@ -871,8 +871,8 @@ themes      : ['Default']
       <p>Disable all dates by default and only enable specific given dates.</p>
       <div class="ui calendar" id="enableddates_calendar">
           <div class="ui input left icon">
-              <i class="calendar icon"></i>
               <input type="text" placeholder="Date">
+              <i class="calendar icon"></i>
           </div>
       </div>
       <div class="code" data-type="javascript">
@@ -896,8 +896,8 @@ themes      : ['Default']
       <p>Mark specific days as events, giving them a different cell style and a tooltip message</p>
       <div class="ui calendar" id="eventdates_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="evaluated code">
@@ -922,8 +922,8 @@ themes      : ['Default']
     <div class="another example">
       <div class="ui calendar" id="eventdates2_calendar">
         <div class="ui fluid input left icon">
-          <i class="calendar icon"></i>
           <input type="text" placeholder="Date">
+          <i class="calendar icon"></i>
         </div>
       </div>
       <div class="evaluated code">

--- a/server/documents/views/card.html.eco
+++ b/server/documents/views/card.html.eco
@@ -68,8 +68,8 @@ themes      : ['Default', 'Basic', 'Classic', 'Instagram']
       </div>
       <div class="extra content">
         <div class="ui large transparent left icon input">
-          <i class="heart outline icon"></i>
           <input type="text" placeholder="Add Comment...">
+          <i class="heart outline icon"></i>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

An icon inside an input gets full opacity on focus. To accomplish this, the icon needs to exist after the input node, so this PR adjusts this wherever the docs didnt do that before

### Before
![image](https://github.com/user-attachments/assets/9042d3f4-d997-413f-a5ee-65f381ccd7a8)

### After
![image](https://github.com/user-attachments/assets/86688cd0-3410-4749-a6d9-281ae7bee545)
