### PR TITLE
fix(divider): vertical variant in stackable grid fix

### DIFF
--- a/server/documents/elements/divider.html.eco
+++ b/server/documents/elements/divider.html.eco
@@ -82,10 +82,8 @@ themes      : ['default']
             <div class="ui blue submit button">Login</div>
           </div>
         </div>
-        <div class="one wide column">
-          <div class="ui vertical divider">
-            Or
-          </div>
+        <div class="ui vertical divider">
+          Or
         </div>
         <div class="middle aligned column">
           <div class="ui big button">

--- a/server/documents/elements/divider.html.eco
+++ b/server/documents/elements/divider.html.eco
@@ -62,7 +62,7 @@ themes      : ['default']
       A vertical divider will automatically swap to a horizontal divider at mobile resolutions when used inside a <a href="/collections/grid.html#stackable-grid"><code>stackable grid</code></a>
     </div>
     <div class="ui placeholder segment">
-      <div class="ui two column very relaxed stackable grid">
+      <div class="ui equal width very relaxed stackable grid">
         <div class="column">
           <div class="ui form">
             <div class="field">
@@ -82,15 +82,17 @@ themes      : ['default']
             <div class="ui blue submit button">Login</div>
           </div>
         </div>
+        <div class="one wide column">
+          <div class="ui vertical divider">
+            Or
+          </div>
+        </div>
         <div class="middle aligned column">
           <div class="ui big button">
             <i class="signup icon"></i>
             Sign Up
           </div>
         </div>
-      </div>
-      <div class="ui vertical divider">
-        Or
       </div>
     </div>
   </div>

--- a/server/documents/elements/divider.html.eco
+++ b/server/documents/elements/divider.html.eco
@@ -62,7 +62,7 @@ themes      : ['default']
       A vertical divider will automatically swap to a horizontal divider at mobile resolutions when used inside a <a href="/collections/grid.html#stackable-grid"><code>stackable grid</code></a>
     </div>
     <div class="ui placeholder segment">
-      <div class="ui equal width very relaxed stackable grid">
+      <div class="ui two column very relaxed stackable grid">
         <div class="column">
           <div class="ui form">
             <div class="field">


### PR DESCRIPTION
## Description

divider inside stackable grids finally got a fix by https://github.com/fomantic/Fomantic-UI/pull/3170
However, the divider needs to be placed between the columns where it should be shown.
