### PR TITLE
feat(dropdown): unlimited height with submenu example

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -1537,6 +1537,39 @@ themes      : ['Default', 'GitHub', 'Material']
       </select>
     </div>
 
+    <div class="another dropdown example">
+         <p>Unlimited should also be used when submenus are desired within a selection dropdown.</p>
+        <div class="ui unlimited selection dropdown">
+          <input type="hidden" name="example">
+          <i class="dropdown icon"></i>
+          <div class="default text">Select an option</div>
+
+          <div class="menu">
+            <div class="item">
+                <span class="text">Category 1</span>
+            </div>
+            <div class="item">
+                <i class="dropdown icon"></i>
+                <span class="text">Category 2</span>
+                <div class="menu">
+                    <div class="item">Item 2A</div>
+                    <div class="item">Item 2B</div>
+                    <div class="item">Item 2C</div>
+                </div>
+            </div>
+            <div class="item">
+                <i class="dropdown icon"></i>
+                <span class="text">Category 3</span>
+                <div class="menu">
+                    <div class="item">Item 3A</div>
+                    <div class="item">Item 3B</div>
+                    <div class="item">Item 3C</div>
+                </div>
+            </div>
+          </div>
+        </div>
+    </div>
+
     <div class="dropdown example">
       <h4 class="ui header">Menu Direction</h4>
       <p>A dropdown menu or sub-menu can specify the direction it should open</p>


### PR DESCRIPTION
## Description

Enhanced the height examples using `unlimited` when submenus are used inside a selection dropdown which was visually adjusted by https://github.com/fomantic/Fomantic-UI/pull/3163^

## Screenshot
![image](https://github.com/user-attachments/assets/e6e2346c-5c96-4420-a1cc-185e50c60851)
