### PR TITLE
feat(emoji): hint that non colon must be rebuild

### DIFF
--- a/server/documents/elements/emoji.html.eco
+++ b/server/documents/elements/emoji.html.eco
@@ -60,6 +60,9 @@ themes      : ['Default']
     <div class="no example">
       <h4 class="ui header">General</h4>
       <p>You can provide the emoji shortname with or without colons</p>
+      <div class="ui ignored info message">
+        Since 2.10.0, if you want to use the non-colon variant, you have to set <code>@variationEmojiNoColons: true;</code> in your custom theme and rebuild Fomantic.
+      </div>
       <div class="code">
           I <em data-emoji=":cupid:"></em> Fomantic-UI
           I <em data-emoji="cupid"></em> Fomantic-UI
@@ -72,7 +75,7 @@ themes      : ['Default']
       <h4 class="ui header">Disabled</h4>
       <p>An emoji can show that it is disabled</p>
       <div class="ui basic massive segment">
-          <em data-emoji="anguished" class="disabled"></em>
+          <em data-emoji=":anguished:" class="disabled"></em>
       </div>
     </div>
 
@@ -80,9 +83,9 @@ themes      : ['Default']
       <h4 class="ui header">Loading</h4>
       <p>An emoji can be used as a simple loader</p>
       <div class="ui basic massive segment">
-          <em data-emoji="angel" class="loading"></em>
-          <em data-emoji="blush" class="loading"></em>
-          <em data-emoji="grin" class="loading"></em>
+          <em data-emoji=":angel:" class="loading"></em>
+          <em data-emoji=":blush:" class="loading"></em>
+          <em data-emoji=":grin:" class="loading"></em>
       </div>
     </div>
 
@@ -92,25 +95,25 @@ themes      : ['Default']
       <h4 class="ui header">Size</h4>
       <p>An emoji can vary in size</p>
       <div class="ui basic segment">
-          <em data-emoji="relaxed" class="small"></em> Small
+          <em data-emoji=":relaxed:" class="small"></em> Small
           <br>
-          <em data-emoji="relaxed" class="medium"></em> Medium
+          <em data-emoji=":relaxed:" class="medium"></em> Medium
           <br>
-          <em data-emoji="relaxed" class="large"></em> Large
+          <em data-emoji=":relaxed:" class="large"></em> Large
           <br>
-          <em data-emoji="relaxed" class="big"></em> Big
+          <em data-emoji=":relaxed:" class="big"></em> Big
       </div>
     </div>
     <div class="another example">
       <h4 className="ui header">Autosizing</h4>
       <p>If no specific size class is given, all emojis are automatically sized according to the current element font-size</p>
       <div class="ui basic segment">
-          <div class="ui small header">Within a header <em data-emoji="relaxed"></em></div>
-          <div class="ui large button">Within a button <em data-emoji="relaxed"></em></div>
+          <div class="ui small header">Within a header <em data-emoji=":relaxed:"></em></div>
+          <div class="ui large button">Within a button <em data-emoji=":relaxed:"></em></div>
           <br><br>
-          <div class="ui massive label">Within a label <em data-emoji="relaxed"></em></div>
+          <div class="ui massive label">Within a label <em data-emoji=":relaxed:"></em></div>
           <br><br>
-          <span class="ui small orange text">Within a text <em data-emoji="relaxed"></em></span>
+          <span class="ui small orange text">Within a text <em data-emoji=":relaxed:"></em></span>
       </div>
     </div>
 
@@ -118,7 +121,7 @@ themes      : ['Default']
       <h4 class="ui header">Link</h4>
       <p>An emoji can be formatted as a link</p>
       <div class="ui basic massive segment">
-          <em data-emoji="slight_smile" class="link"></em>
+          <em data-emoji=":slight_smile:" class="link"></em>
       </div>
     </div>
 

--- a/server/documents/elements/emoji.html.eco
+++ b/server/documents/elements/emoji.html.eco
@@ -61,7 +61,7 @@ themes      : ['Default']
       <h4 class="ui header">General</h4>
       <p>You can provide the emoji shortname with or without colons</p>
       <div class="ui ignored info message">
-        Since 2.10.0, if you want to use the non-colon variant, you have to set <code>@variationEmojiNoColons: true;</code> in your custom theme and rebuild Fomantic.
+        Since 2.10.0, if you want to use the non-colon variant, you have to set <code>@variationEmojiNoColons: true;</code> inside <a href="/introduction/build-tools.html#variationvariables">variation.variables</a> in your custom theme and <a href="/introduction/build-tools.html">rebuild Fomantic</a>.
       </div>
       <div class="code">
           I <em data-emoji=":cupid:"></em> Fomantic-UI

--- a/server/documents/introduction/new.html.eco
+++ b/server/documents/introduction/new.html.eco
@@ -313,7 +313,7 @@ type        : 'Main'
 
   <div class="ui tab" data-tab="twoeight">
     <h2 class="ui dividing header">Toasty Emotion</h2>
-    <p>Fomantic <code>2.8</code> brings some of the best updates yet including variation feature customization for components, more toast changes and EMOTES <em data-emoji="tada"></em> <em data-emoji="smile"></em> and of course A LOT of critical and much needed bug fixes.</p>
+    <p>Fomantic <code>2.8</code> brings some of the best updates yet including variation feature customization for components, more toast changes and EMOTES <em data-emoji=":tada:"></em> <em data-emoji="smile"></em> and of course A LOT of critical and much needed bug fixes.</p>
 
     <p>Since this is a breaking changes update here is a list of breaking changes:</p>
     <div class="ui bulleted list">
@@ -397,7 +397,7 @@ type        : 'Main'
 
       <p><code>2.8</code> introduces the new emoji element with support for all <a href="https://unicode.org/emoji/charts/full-emoji-list.html">Unicode 12.1 Emoji Characters</a>.</p>
 
-      <p><em data-emoji="tada" class="large"></em> <em data-emoji="partying_face" class="large"></em> <em data-emoji="champagne" class="large"></em></p>
+      <p><em data-emoji=":tada:" class="large"></em> <em data-emoji=":partying_face:" class="large"></em> <em data-emoji=":champagne:" class="large"></em></p>
 
       <p>You can find a full list of all emojis <a href="/elements/emoji.html">here</a>.</p>
     </div>
@@ -407,7 +407,7 @@ type        : 'Main'
         Dynamic LESS Compilation
       </h4>
 
-      <p>In <code>2.8</code> we are introducing a new feature for building custom themes, Dynamic LESS Compilation. This new feature allows you to disable specific variations of components allowing you to generate CSS files which only contain features you require. This makes your custom distribution files much smaller in size speeding up your website <em data-emoji="clap"></em></p>
+      <p>In <code>2.8</code> we are introducing a new feature for building custom themes, Dynamic LESS Compilation. This new feature allows you to disable specific variations of components allowing you to generate CSS files which only contain features you require. This makes your custom distribution files much smaller in size speeding up your website <em data-emoji=":clap:"></em></p>
     </div>
 
     <div class="content example">


### PR DESCRIPTION
## Description

Adjusted all emojis to use colon variant as the non colon variant is not compiled by default anymore as of https://github.com/fomantic/Fomantic-UI/pull/3221
Also added a hint how to enable it again via rebuild

## Screenshot
![image](https://github.com/user-attachments/assets/63b2ddaf-bb4e-4392-9a89-57fbe2d45549)


