### PR TITLE
feat(menu): rename tabular to tabbed

### DIFF
--- a/server/documents/collections/grid.html.eco
+++ b/server/documents/collections/grid.html.eco
@@ -201,7 +201,7 @@ themes      : ['Default']
 
     <div class="highlighted example" data-use-content="true" data-class="left attached, right attached" data-since="2.9.2">
       <h4 class="ui header">Left / Right Attached Column</h4>
-      <p>A column can be attached to the left or right without any padding. This is especially useful when working with a <a href="/collections/menu.html#tabular"><code>vertical tabular menu</code></a></p>
+      <p>A column can be attached to the left or right without any padding. This is especially useful when working with a <a href="/collections/menu.html#tabbed"><code>vertical tabbed menu</code></a></p>
       <div class="ui two column grid">
         <div class="left attached column"></div>
         <div class="right attached column"></div>

--- a/server/documents/collections/menu.html.eco
+++ b/server/documents/collections/menu.html.eco
@@ -208,12 +208,15 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   </div>
 
   <div class="example">
-    <h4 class="ui header">Tabular</h4>
+    <h4 class="ui header">Tabbed</h4>
     <p>A menu can be formatted to show tabs of information</p>
+    <div class="ui ignored message">
+      Before 2.10.0, this variation was named <code>tabular</code>. For quicker migration, you can enable the old naming by setting <code>@variationMenuTabbedLegacyTabular: true;</code> inside <a href="/introduction/build-tools.html#variationvariables">variation.variables</a> in your custom theme and <a href="/introduction/build-tools.html">rebuild Fomantic</a>
+    </div>
     <div class="ui ignored info message">
       Be sure to visit the <a href="/modules/tab.html">tab documentation</a> for information on how to set up dynamic tabs
     </div>
-    <div class="ui tabular menu">
+    <div class="ui tabbed menu">
       <a class="active item">
         Bio
       </a>
@@ -223,7 +226,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
     </div>
   </div>
   <div class="another example">
-    <div class="ui top attached tabular menu">
+    <div class="ui top attached tabbed menu">
       <a class="active item">
         Bio
       </a>
@@ -247,7 +250,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
     <div class="ui top attached segment">
       <img class="ui wireframe image" src="/images/wireframe/paragraph.png">
     </div>
-    <div class="ui bottom attached tabular menu">
+    <div class="ui bottom attached tabbed menu">
       <a class="active item">
         Active Project
       </a>
@@ -266,11 +269,11 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   </div>
   <div class="another example">
     <div class="ui ignored info message">
-        To make a vertical tabular menu appear seamless attached to the related segment, you should make use of <a href="/collections/grid.html#left--right-attached-column">left/right attached grid columns</a> and <a href="/elements/segment.html#seamless-attached">seamless attached segments</a>
+        To make a vertical tabbed menu appear seamless attached to the related segment, you should make use of <a href="/collections/grid.html#left--right-attached-column">left/right attached grid columns</a> and <a href="/elements/segment.html#seamless-attached">seamless attached segments</a>
     </div>
     <div class="ui grid">
       <div class="four wide left attached column">
-        <div class="ui vertical fluid tabular menu">
+        <div class="ui vertical fluid tabbed menu">
           <a class="active item">
             Bio
           </a>
@@ -300,7 +303,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
         </div>
       </div>
       <div class="four wide right attached column">
-        <div class="ui vertical fluid right tabular menu">
+        <div class="ui vertical fluid right tabbed menu">
           <a class="active item">
             Bio
           </a>
@@ -1345,7 +1348,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   <div class="example" data-class="!top attached, !bottom attached">
     <h4 class="ui header">Attached</h4>
     <p>A menu may be attached to other content segments</p>
-    <div class="ui top attached tabular menu">
+    <div class="ui top attached tabbed menu">
       <a class="active item">
         Tab 1
       </a>

--- a/server/documents/elements/segment.html.eco
+++ b/server/documents/elements/segment.html.eco
@@ -461,7 +461,7 @@ themes      : ['default', 'GitHub']
 
   <div class="example" data-since="2.9.2">
       <h4 class="ui header">Seamless attached</h4>
-      <p>A segment can be seamless attached removing the related sides border. This is especially useful when working with a <a href="/collections/menu.html#tabular"><code>vertical tabular menu</code></a></p>
+      <p>A segment can be seamless attached removing the related sides border. This is especially useful when working with a <a href="/collections/menu.html#tabbed"><code>vertical tabbed menu</code></a></p>
       <div class="ui horizontal segments">
           <div class="ui seamless left attached right aligned segment">
             <p>This segment is seamless left attached</p>

--- a/server/documents/index.html.eco
+++ b/server/documents/index.html.eco
@@ -292,7 +292,7 @@ standalone : false
               </div>
             </div>
           </div>
-          <div class="ui fluid demo tabular menu">
+          <div class="ui fluid demo tabbed menu">
             <a class="active item">
               Tab
             </a>

--- a/server/documents/introduction/new.html.eco
+++ b/server/documents/introduction/new.html.eco
@@ -275,7 +275,7 @@ type        : 'Main'
       <div class="item">
         <div>Tab</div>
         <div class="list">
-          <div class="item">Tabular menus and their related segments have to stay in a dedicated parent node to allow more than two attached segments</div>
+          <div class="item">Tabbed menus and their related segments have to stay in a dedicated parent node to allow more than two attached segments</div>
         </div>
       </div>
       <div class="item">

--- a/server/documents/modules/sticky.html.eco
+++ b/server/documents/modules/sticky.html.eco
@@ -386,7 +386,7 @@ type        : 'UI Module'
       </div>
       <div class="ui segment">
         <div class="ui sticky">
-          <div class="ui fluid three item tabular menu">
+          <div class="ui fluid three item tabbed menu">
             <a class="active item">Tab 1</a>
             <a class="item">Tab 2</a>
             <a class="item">Tab 3</a>

--- a/server/documents/modules/tab.html.eco
+++ b/server/documents/modules/tab.html.eco
@@ -31,7 +31,7 @@ themes      : ['Default']
       </h4>
       <p>A basic tab</p>
       <div class="ui ignored info message">A tab is hidden by default, and will only become visible when given the class name <code>active</code> or when activated with Javascript. For more information, see the usage section.</div>
-      <div class="ui top attached tabular menu">
+      <div class="ui top attached tabbed menu">
         <div class="item">Tab</div>
       </div>
       <div class="ui bottom attached tab segment">
@@ -49,7 +49,7 @@ themes      : ['Default']
         Active
       </h4>
       <p>A tab can be activated, and visible on the page</p>
-      <div class="ui top attached tabular menu">
+      <div class="ui top attached tabbed menu">
         <div class="active item">Tab</div>
       </div>
       <div class="ui bottom attached active tab segment">
@@ -63,7 +63,7 @@ themes      : ['Default']
         Loading
       </h4>
       <p>A tab can display a loading indicator</p>
-      <div class="ui top attached tabular menu">
+      <div class="ui top attached tabbed menu">
         <div class="active item">Tab</div>
       </div>
       <div class="ui bottom attached loading tab segment">
@@ -81,7 +81,7 @@ themes      : ['Default']
         Centered Item
       </h4>
       <p>A tab can have center aligned items</p>
-      <div class="ui top attached tabular menu">
+      <div class="ui top attached tabbed menu">
         <div class="active item" data-tab="one">One</div>
         <div class="center item" data-tab="two">Two</div>
         <div class="item" data-tab="three">Three</div>
@@ -106,7 +106,7 @@ themes      : ['Default']
       </h4>
       <p>A tab can be shown inverted</p>
       <div class="ui inverted segment">
-        <div class="ui top attached inverted tabular menu">
+        <div class="ui top attached inverted tabbed menu">
           <a class="active item" data-tab="one">Active Tab</a>
           <a class="item" data-tab="two">Tab 2</a>
           <a class="item" data-tab="three">Tab 3</a>
@@ -127,7 +127,7 @@ themes      : ['Default']
       <h4 class="ui header">
         Bottom attached menu
       </h4>
-      <p>You can display the tabular menu at the bottom of the tab segments</p>
+      <p>You can display the tabbed menu at the bottom of the tab segments</p>
       <div class="ui inverted segment">
         <div class="ui top attached inverted tab segment" data-tab="one1">
           <p>content one</p>
@@ -138,7 +138,7 @@ themes      : ['Default']
         <div class="ui top attached inverted tab segment active" data-tab="three1">
           <p>content three</p>
         </div>
-        <div class="ui bottom attached inverted tabular menu">
+        <div class="ui bottom attached inverted tabbed menu">
           <a class="item" data-tab="one1">Active Tab</a>
           <a class="item" data-tab="two1">Tab 2</a>
           <a class="item active" data-tab="three1">Tab 3</a>
@@ -158,7 +158,7 @@ themes      : ['Default']
       <div class="ui ignored info message">
         To have a tab visible on page load, add the class <code>active</code> to both the initializing menu and the tab.
       </div>
-      <div class="ui top attached tabular menu">
+      <div class="ui top attached tabbed menu">
         <a class="active item" data-tab="first">First</a>
         <a class="item" data-tab="second">Second</a>
         <a class="item" data-tab="third">Third</a>
@@ -205,7 +205,7 @@ themes      : ['Default']
           <a class="item" data-tab="third">Third</a>
         </div>
         <div class="ui tab segment" data-tab="first">
-          <div class="ui top attached tabular menu">
+          <div class="ui top attached tabbed menu">
             <a class="active item" data-tab="first/a">1A</a>
             <a class="item" data-tab="first/b">1B</a>
             <a class="item" data-tab="first/c">1C</a>
@@ -215,7 +215,7 @@ themes      : ['Default']
           <div class="ui bottom attached tab segment" data-tab="first/c">1C</div>
         </div>
         <div class="ui tab segment active" data-tab="second">
-          <div class="ui top attached tabular menu">
+          <div class="ui top attached tabbed menu">
             <a class="item" data-tab="second/a">2A</a>
             <a class="item" data-tab="second/b">2B</a>
             <a class="item active" data-tab="second/c">2C</a>
@@ -225,7 +225,7 @@ themes      : ['Default']
           <div class="ui bottom attached tab segment active" data-tab="second/c">2C</div>
         </div>
         <div class="ui tab segment" data-tab="third">
-          <div class="ui top attached tabular menu">
+          <div class="ui top attached tabbed menu">
             <a class="item" data-tab="third/a">3A</a>
             <a class="item" data-tab="third/b">3B</a>
             <a class="item" data-tab="third/c">3C</a>
@@ -260,7 +260,7 @@ themes      : ['Default']
             <a class="item" data-tab="third">Third</a>
           </div>
           <div class="ui tab segment" data-tab="first">
-            <div class="ui top attached tabular menu">
+            <div class="ui top attached tabbed menu">
               <a class="active item" data-tab="first/a">1A</a>
               <a class="item" data-tab="first/b">1B</a>
               <a class="item" data-tab="first/c">1C</a>
@@ -270,7 +270,7 @@ themes      : ['Default']
             <div class="ui bottom attached tab segment" data-tab="first/c">1C</div>
           </div>
           <div class="ui tab segment active" data-tab="second">
-            <div class="ui top attached tabular menu">
+            <div class="ui top attached tabbed menu">
               <a class="item" data-tab="second/a">2A</a>
               <a class="item" data-tab="second/b">2B</a>
               <a class="item active" data-tab="second/c">2C</a>
@@ -280,7 +280,7 @@ themes      : ['Default']
             <div class="ui bottom attached tab segment active" data-tab="second/c">2C</div>
           </div>
           <div class="ui tab segment" data-tab="third">
-            <div class="ui top attached tabular menu">
+            <div class="ui top attached tabbed menu">
               <a class="item" data-tab="third/a">3A</a>
               <a class="item" data-tab="third/b">3B</a>
               <a class="item" data-tab="third/c">3C</a>
@@ -329,7 +329,7 @@ themes      : ['Default']
         <a class="item" data-tab="third">Third</a>
       </div>
       <div class="ui active tab segment" data-tab="first">
-        <div class="ui top attached tabular menu">
+        <div class="ui top attached tabbed menu">
           <a class="active item" data-tab="first/a">1A</a>
           <a class="item" data-tab="first/b">1B</a>
           <a class="item" data-tab="first/c">1C</a>
@@ -339,7 +339,7 @@ themes      : ['Default']
         <div class="ui bottom attached tab segment" data-tab="first/c">1C</div>
       </div>
       <div class="ui tab segment" data-tab="second">
-        <div class="ui top attached tabular menu">
+        <div class="ui top attached tabbed menu">
           <a class="item" data-tab="second/a">2A</a>
           <a class="item" data-tab="second/b">2B</a>
           <a class="item" data-tab="second/c">2C</a>
@@ -349,7 +349,7 @@ themes      : ['Default']
         <div class="ui bottom attached tab segment" data-tab="second/c">2C</div>
       </div>
       <div class="ui tab segment" data-tab="third">
-        <div class="ui top attached tabular menu">
+        <div class="ui top attached tabbed menu">
           <a class="item" data-tab="third/a">3A</a>
           <a class="item" data-tab="third/b">3B</a>
           <a class="item" data-tab="third/c">3C</a>
@@ -459,7 +459,7 @@ themes      : ['Default']
         <a class="item" data-tab="third">Third</a>
       </div>
       <div class="ui active tab segment" data-tab="first">
-        <div class="ui top attached tabular menu">
+        <div class="ui top attached tabbed menu">
           <a class="active item" data-tab="first/a">1A</a>
           <a class="item" data-tab="first/b">1B</a>
           <a class="item" data-tab="first/c">1C</a>
@@ -469,7 +469,7 @@ themes      : ['Default']
         <div class="ui bottom attached tab segment" data-tab="first/c">1C</div>
       </div>
       <div class="ui tab segment" data-tab="second">
-        <div class="ui top attached tabular menu">
+        <div class="ui top attached tabbed menu">
           <a class="item" data-tab="second/a">2A</a>
           <a class="item" data-tab="second/b">2B</a>
           <a class="item" data-tab="second/c">2C</a>
@@ -479,7 +479,7 @@ themes      : ['Default']
         <div class="ui bottom attached tab segment" data-tab="second/c">2C</div>
       </div>
       <div class="ui tab segment" data-tab="third">
-        <div class="ui top attached tabular menu">
+        <div class="ui top attached tabbed menu">
           <a class="item" data-tab="third/a">3A</a>
           <a class="item" data-tab="third/b">3B</a>
           <a class="item" data-tab="third/c">3C</a>
@@ -522,10 +522,10 @@ themes      : ['Default']
       <p>Tabs are connected to their activators with a metadata attribute <code>data-tab</code>. This should be added to both the activating element and the tab itself.</p>
 
       <div class="code" data-type="javascript">
-        $('.tabular.menu .item').tab();
+        $('.tabbed.menu .item').tab();
       </div>
       <div class="code" data-type="html">
-        <div class="ui tabular menu">
+        <div class="ui tabbed menu">
           <div class="item" data-tab="tab-name">Tab Name</div>
           <div class="item" data-tab="tab-name2">Tab Name 2</div>
         </div>
@@ -568,10 +568,10 @@ themes      : ['Default']
       </div>
       <div class="ignored ui warning message">
         <h4 class="ui header">Using tab segments</h4>
-        <p>To avoid possible CSS issues when using <code>attached segments</code> you should wrap your tabular menu tab and related attached tab segments into a dedicated DOM node, for example a <code>ui segment</code></p>
+        <p>To avoid possible CSS issues when using <code>attached segments</code> you should wrap your tabbed menu tab and related attached tab segments into a dedicated DOM node, for example a <code>ui segment</code></p>
        <div class="code" data-type="html">
           <div class="ui basic segment">
-            <div class="ui top attached tabular menu">
+            <div class="ui top attached tabbed menu">
               <a class="item" data-tab="entries">Tab menu item</a>
             </div>
             <div class="ui bottom attached tab segment" data-tab="entries">

--- a/server/files/javascript/tab.js
+++ b/server/files/javascript/tab.js
@@ -19,7 +19,7 @@ semantic.tab.ready = function() {
     })
   ;
 
-  $('.center.example .tabular.menu .item')
+  $('.center.example .tabbed.menu .item')
     .tab({
       context: '.center.example'
     })

--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -255,11 +255,11 @@ blockquote .author {
   display: none;
   margin: 2rem 0 1rem;
 }
-#example .tab.masthead.segment .tabular.menu {
+#example .tab.masthead.segment .tabbed.menu {
   margin: 3rem 0 0;
   border-bottom: none;
 }
-#example .tab.masthead.segment .tabular.menu .active.item {
+#example .tab.masthead.segment .tabbed.menu .active.item {
   background-color: #F7F7F7;
 }
 
@@ -340,7 +340,7 @@ blockquote .author {
   margin: 3rem 0 2rem;
 }
 
-#example .tab.masthead.segment .fixed .tabular.menu {
+#example .tab.masthead.segment .fixed .tabbed.menu {
   position: fixed;
   top: 50px;
 }

--- a/server/partials/examples/menu.html
+++ b/server/partials/examples/menu.html
@@ -24,7 +24,7 @@
     </div>
   </div>
 </div>
-<div class="ui tabular menu">
+<div class="ui tabbed menu">
   <a class="active item">
     Tab
   </a>

--- a/server/partials/examples/tab.html
+++ b/server/partials/examples/tab.html
@@ -5,7 +5,7 @@
     <a class="item" data-tab="third">Third</a>
   </div>
   <div class="ui tab segment" data-tab="first">
-    <div class="ui top attached tabular menu">
+    <div class="ui top attached tabbed menu">
       <a class="active item" data-tab="first/a">1A</a>
       <a class="item" data-tab="first/b">1B</a>
       <a class="item" data-tab="first/c">1C</a>
@@ -15,7 +15,7 @@
     <div class="ui bottom attached tab segment" data-tab="first/c">1C</div>
   </div>
   <div class="ui tab segment active" data-tab="second">
-    <div class="ui top attached tabular menu">
+    <div class="ui top attached tabbed menu">
       <a class="item" data-tab="second/a">2A</a>
       <a class="item" data-tab="second/b">2B</a>
       <a class="item active" data-tab="second/c">2C</a>
@@ -25,7 +25,7 @@
     <div class="ui bottom attached tab segment active" data-tab="second/c">2C</div>
   </div>
   <div class="ui tab segment" data-tab="third">
-    <div class="ui top attached tabular menu">
+    <div class="ui top attached tabbed menu">
       <a class="item" data-tab="third/a">3A</a>
       <a class="item" data-tab="third/b">3B</a>
       <a class="item" data-tab="third/c">3C</a>


### PR DESCRIPTION
## Description

Renamed everything from "tabular" to "tabbed"  as of https://github.com/fomantic/Fomantic-UI/pull/3201
and added a hint how to compil using the old naming for quicker migration

## Screenshot
![image](https://github.com/user-attachments/assets/3c6234d8-3148-4c2e-87f2-5cf1a04c1171)
