### PR TITLE
feat(table): info about loose padding for very basic tables

### DIFF
--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -1163,7 +1163,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
   </div>
   <div class="another example">
     <div class="ui ignored info message">
-        <code>very basic</code> tables have lose padding unless they are also <a href="#sortable"><code>sortable</code></a> or <a href="#striped"><code>striped</code></a>.
+        <code>very basic</code> tables have loose padding unless they are also <a href="#sortable"><code>sortable</code></a> or <a href="#striped"><code>striped</code></a>.
     </div>
     <table class="ui very basic table">
       <thead>

--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -1162,6 +1162,9 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
     </table>
   </div>
   <div class="another example">
+    <div class="ui ignored info message">
+        <code>very basic</code> tables have lose padding unless they are also <a href="#sortable"><code>sortable</code></a> or <a href="#striped"><code>striped</code></a>.
+    </div>
     <table class="ui very basic table">
       <thead>
         <tr>


### PR DESCRIPTION
## Description

Added some info about loose padding for "very basic" variant as a suggestion from a discord user

## Screenshot
 
<img width="932" height="120" alt="image" src="https://github.com/user-attachments/assets/4fda1078-2b9c-4d93-a101-a0457bd42e67" />
